### PR TITLE
Fixes firestone repair bug

### DIFF
--- a/src/main/java/mods/railcraft/common/items/firestone/ItemFirestoneBase.java
+++ b/src/main/java/mods/railcraft/common/items/firestone/ItemFirestoneBase.java
@@ -56,4 +56,13 @@ public abstract class ItemFirestoneBase extends ItemRailcraft {
         return entity;
     }
 
+    /**
+     * Called by CraftingManager to determine if an item is reparable.
+     * @return Always returns false for ItemFirestoneBase
+     */
+    @Override
+    public boolean isRepairable() {
+        return false;
+    }
+
 }


### PR DESCRIPTION
Fixes https://github.com/CovertJaguar/Railcraft/issues/331

Fixed by overriding isRepairable() in ItemFirestoneBase.
Alternatively it could call setNoRepair() during each subclass registerItem(), but this seemed simpler.
