### PR TITLE
Rock crusher can receive recipes via IMC (as requested on #332)

### DIFF
--- a/src/main/java/mods/railcraft/common/core/Railcraft.java
+++ b/src/main/java/mods/railcraft/common/core/Railcraft.java
@@ -20,6 +20,8 @@ import cpw.mods.fml.common.registry.GameRegistry;
 import java.io.File;
 import org.apache.logging.log4j.Level;
 import mods.railcraft.common.plugins.forge.ItemRegistry;
+import mods.railcraft.api.crafting.IRockCrusherRecipe;
+import mods.railcraft.api.crafting.RailcraftCraftingManager;
 import mods.railcraft.api.fuel.FuelManager;
 import mods.railcraft.common.blocks.aesthetics.cube.EnumCube;
 import mods.railcraft.common.blocks.machine.alpha.EnumMachineAlpha;
@@ -125,6 +127,15 @@ public final class Railcraft {
                 }
                 FuelManager.addBoilerFuel(fluid, fuel);
                 Game.log(Level.INFO, String.format("Mod %s registered %s as a valid liquid Boiler fuel", mess.getSender(), mess.getStringValue()));
+            } else if (mess.key.equals("rock-crusher")) {
+               NBTTagCompound nbt = mess.getNBTValue();
+			ItemStack input = ItemStack.loadItemStackFromNBT(nbt.getCompoundTag("input"));
+			IRockCrusherRecipe recipe = RailcraftCraftingManager.rockCrusher.createNewRecipe(input, nbt.getBoolean("matchMeta"), nbt.getBoolean("matchNBT"));
+			for (int i = 0; i < 9; i++)
+				if (nbt.hasKey("output" + i)) {
+				     NBTTagCompound outputNBT = nbt.getCompoundTag("output" + i);
+					recipe.addOutput(ItemStack.loadItemStackFromNBT(outputNBT), outputNBT.getFloat("chance"));
+				}
             }
         }
     }


### PR DESCRIPTION
Not sure if it's up to your standards but I decided t give it a try :)

I made this helper method that automatically encodes all the data into a NBT tag and sends it. Thought it would be useful in case you want to include it somewhere to help people figure out how to use the message properly.

``` JAVA
public void addRockCrusherRecipe(ItemStack input, boolean matchMeta, boolean matchNBT, Map<ItemStack, Float> outputs) {
    NBTTagCompound nbt = new NBTTagCompound();

    NBTTagCompound inputNBT = new NBTTagCompound();
    input.writeToNBT(inputNBT);
    nbt.setTag("input", inputNBT);

    nbt.setBoolean("matchMeta", matchMeta);
    nbt.setBoolean("matchNBT", matchNBT);

    int outCount = 0;
    for (Entry<ItemStack, Float> output : outputs.entrySet()) {
        NBTTagCompound outputNBT = new NBTTagCompound();
        output.getKey().writeToNBT(outputNBT);
        outputNBT.setFloat("chance", output.getValue());
        nbt.setTag("output" + outCount++, outputNBT);
    }

    FMLInterModComms.sendMessage("Railcraft", "rock-crusher", nbt);
}
```
