### PR TITLE
Fixes #869 Cart dupe

### DIFF
--- a/src/main/java/mods/railcraft/common/util/crafting/CartFilterRecipe.java
+++ b/src/main/java/mods/railcraft/common/util/crafting/CartFilterRecipe.java
@@ -77,6 +77,7 @@ public class CartFilterRecipe implements IRecipe {
                 cartSlot = slot.getIndex();
                 filterType = type;
                 cartItem = stack.copy();
+                cartItem.stackSize = 1;
             }
         }
         if (filterType == null || itemCount > 2)

--- a/src/main/java/mods/railcraft/common/util/crafting/CraftingHandler.java
+++ b/src/main/java/mods/railcraft/common/util/crafting/CraftingHandler.java
@@ -11,17 +11,15 @@ package mods.railcraft.common.util.crafting;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent.ItemCraftedEvent;
 import mods.railcraft.common.carts.EntityCartFiltered;
-import mods.railcraft.common.carts.EntityCartTank;
+import mods.railcraft.common.carts.EnumCart;
 import mods.railcraft.common.carts.ICartType;
-import mods.railcraft.common.fluids.FluidItemHelper;
+import mods.railcraft.common.items.firestone.ItemFirestoneCracked;
 import mods.railcraft.common.util.inventory.InvTools;
 import mods.railcraft.common.util.inventory.wrappers.IInvSlot;
 import mods.railcraft.common.util.inventory.wrappers.InventoryIterator;
-import net.minecraft.item.ItemStack;
-import mods.railcraft.common.carts.EnumCart;
-import mods.railcraft.common.items.firestone.ItemFirestoneCracked;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
 
 public class CraftingHandler {
 
@@ -51,9 +49,13 @@ public class CraftingHandler {
                     for (IInvSlot slot : InventoryIterator.getIterable(craftMatrix).notNull()) {
                         ItemStack stack = slot.getStackInSlot();
                         if (InvTools.isItemEqual(stack, filterItem)) {
-                            if (!player.inventory.addItemStackToInventory(stack))
-                                player.dropPlayerItemWithRandomChoice(stack, false);
-                            slot.setStackInSlot(null);
+                            if (cartItem.stackSize == 1) {
+                                if (!player.inventory.addItemStackToInventory(stack))
+                                    player.dropPlayerItemWithRandomChoice(stack, false);
+                                slot.setStackInSlot(null);
+                            } else {
+                                stack.stackSize++;
+                            }
                         }
                     }
                 return;


### PR DESCRIPTION
Ref #869.

Change for `CartFilterRecipe.java` fixes the incorrect amount of recipe output.
Change for `CraftingHandler.java` allows you either to craft by one click or shift click. When there's no more cart left in the crafting grid the filter item stack returns to the player.

Tested in dev env.
