### PR TITLE
Simple fix for #1006

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/ore/BlockOre.java
+++ b/src/main/java/mods/railcraft/common/blocks/ore/BlockOre.java
@@ -59,7 +59,7 @@ public class BlockOre extends RailcraftBlockSubtyped<EnumOre> {
 
     @Override
     public void defineRecipes() {
-        registerOreRecipe(Metal.IRON);
+        registerOreRecipe(Metal.COPPER);
         registerOreRecipe(Metal.TIN);
         registerOreRecipe(Metal.LEAD);
         registerOreRecipe(Metal.SILVER);


### PR DESCRIPTION
See #1006. 
Iron does not need to be defined.
Edited on Github because it is really a simple fix.