### PR TITLE
Fixes issue #998

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/tracks/behaivor/CollisionHandler.java
+++ b/src/main/java/mods/railcraft/common/blocks/tracks/behaivor/CollisionHandler.java
@@ -47,9 +47,11 @@ public enum CollisionHandler {
                     EntityPlayer player = ((EntityPlayer) entity);
                     ItemStack pants = player.getItemStackFromSlot(EntityEquipmentSlot.LEGS);
                     if (pants != null && RailcraftItems.OVERALLS.isInstance(pants)
-                            && !((EntityPlayer) entity).capabilities.isCreativeMode
-                            && MiscTools.RANDOM.nextInt(150) == 0) {
-                        player.setItemStackToSlot(EntityEquipmentSlot.LEGS, InvTools.damageItem(pants, 1));
+                            && !((EntityPlayer) entity).capabilities.isCreativeMode) {
+                        if(MiscTools.RANDOM.nextInt(150) == 0)
+                            player.setItemStackToSlot(EntityEquipmentSlot.LEGS, InvTools.damageItem(pants, 1));
+                    } else if (entity.attackEntityFrom(RailcraftDamageSource.TRACK_ELECTRIC, 2)) {
+                        graph.removeCharge(2000);
                     }
                 } else if (entity.attackEntityFrom(RailcraftDamageSource.TRACK_ELECTRIC, 2))
                     graph.removeCharge(2000);


### PR DESCRIPTION
As stated in issue #998, this fixes players not getting damaged by electric tracks.

Wearing Engineer's Overalls prevents damage to the user and instead damages the overalls slowly.