### PR TITLE
Fix supplying null entries into the creative list

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/BlockContainerRailcraftSubtyped.java
+++ b/src/main/java/mods/railcraft/common/blocks/BlockContainerRailcraftSubtyped.java
@@ -13,6 +13,7 @@ package mods.railcraft.common.blocks;
 import com.google.common.collect.BiMap;
 import mods.railcraft.api.core.IVariantEnum;
 import mods.railcraft.common.blocks.machine.RailcraftBlockMetadata;
+import mods.railcraft.common.plugins.forge.CreativePlugin;
 import mods.railcraft.common.util.collections.CollectionTools;
 import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
@@ -111,10 +112,10 @@ public abstract class BlockContainerRailcraftSubtyped<V extends Enum<V> & IVaria
         V[] variants = getVariants();
         if (variants != null) {
             for (V variant : variants) {
-                list.add(getStack(variant));
+                CreativePlugin.addToList(list, getStack(variant));
             }
         } else {
-            list.add(getStack(null));
+            CreativePlugin.addToList(list, getStack(null));
         }
     }
 

--- a/src/main/java/mods/railcraft/common/blocks/BlockRailcraftSubtyped.java
+++ b/src/main/java/mods/railcraft/common/blocks/BlockRailcraftSubtyped.java
@@ -12,6 +12,7 @@ package mods.railcraft.common.blocks;
 
 import mods.railcraft.api.core.IVariantEnum;
 import mods.railcraft.common.blocks.machine.RailcraftBlockMetadata;
+import mods.railcraft.common.plugins.forge.CreativePlugin;
 import mods.railcraft.common.util.collections.ArrayTools;
 import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
@@ -96,10 +97,10 @@ public abstract class BlockRailcraftSubtyped<V extends Enum<V> & IVariantEnum> e
         if (variants != null) {
             for (V variant : variants) {
                 if (!variant.isDeprecated())
-                    list.add(getStack(variant));
+                    CreativePlugin.addToList(list, getStack(variant));
             }
         } else {
-            list.add(getStack(null));
+            CreativePlugin.addToList(list, getStack(null));
         }
     }
 

--- a/src/main/java/mods/railcraft/common/blocks/aesthetics/brick/BlockBrick.java
+++ b/src/main/java/mods/railcraft/common/blocks/aesthetics/brick/BlockBrick.java
@@ -106,7 +106,7 @@ public class BlockBrick extends BlockRailcraftSubtyped<BrickVariant> {
     @Override
     public void getSubBlocks(Item item, CreativeTabs tab, List<ItemStack> list) {
         for (BrickVariant variant : BrickVariant.VALUES) {
-            list.add(theme.getStack(1, variant));
+            CreativePlugin.addToList(list, theme.getStack(1, variant));
         }
     }
 

--- a/src/main/java/mods/railcraft/common/blocks/aesthetics/generic/BlockGeneric.java
+++ b/src/main/java/mods/railcraft/common/blocks/aesthetics/generic/BlockGeneric.java
@@ -180,7 +180,7 @@ public class BlockGeneric extends BlockRailcraftSubtyped<EnumGeneric> {
     public void getSubBlocks(Item item, CreativeTabs tab, List<ItemStack> list) {
         for (EnumGeneric type : EnumGeneric.getCreativeList()) {
             if (type.isEnabled())
-                list.add(type.getStack());
+                CreativePlugin.addToList(list, type.getStack());
         }
     }
 

--- a/src/main/java/mods/railcraft/common/blocks/aesthetics/materials/BlockLantern.java
+++ b/src/main/java/mods/railcraft/common/blocks/aesthetics/materials/BlockLantern.java
@@ -19,6 +19,7 @@ import mods.railcraft.common.plugins.forge.CreativePlugin;
 import mods.railcraft.common.plugins.forge.RailcraftRegistry;
 import mods.railcraft.common.util.misc.AABBFactory;
 import mods.railcraft.common.util.misc.Game;
+import mods.railcraft.common.util.misc.Predicates;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
@@ -123,7 +124,7 @@ public class BlockLantern extends BlockRailcraft implements IMaterialBlock {
 
     @Override
     public void getSubBlocks(@Nonnull Item item, CreativeTabs tab, List<ItemStack> list) {
-        list.addAll(Materials.getCreativeList().stream().filter(m -> !Materials.MAT_SET_FROZEN.contains(m)).map(this::getStack).collect(Collectors.toList()));
+        list.addAll(Materials.getCreativeList().stream().filter(m -> !Materials.MAT_SET_FROZEN.contains(m)).map(this::getStack).filter(Predicates.nonNull()).collect(Collectors.toList()));
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/blocks/aesthetics/materials/BlockRailcraftStairs.java
+++ b/src/main/java/mods/railcraft/common/blocks/aesthetics/materials/BlockRailcraftStairs.java
@@ -17,6 +17,7 @@ import mods.railcraft.common.plugins.forge.CraftingPlugin;
 import mods.railcraft.common.plugins.forge.CreativePlugin;
 import mods.railcraft.common.plugins.forge.RailcraftRegistry;
 import mods.railcraft.common.util.misc.Game;
+import mods.railcraft.common.util.misc.Predicates;
 import mods.railcraft.common.util.sounds.RailcraftSoundTypes;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockStairs;
@@ -130,7 +131,7 @@ public class BlockRailcraftStairs extends BlockStairs implements IMaterialBlock 
 
     @Override
     public void getSubBlocks(@Nonnull Item item, CreativeTabs tab, List<ItemStack> list) {
-        list.addAll(Materials.getCreativeList().stream().map(this::getStack).collect(Collectors.toList()));
+        list.addAll(Materials.getCreativeList().stream().map(this::getStack).filter(Predicates.nonNull()).collect(Collectors.toList()));
     }
 
     @Nonnull

--- a/src/main/java/mods/railcraft/common/blocks/aesthetics/materials/BlockRailcraftWall.java
+++ b/src/main/java/mods/railcraft/common/blocks/aesthetics/materials/BlockRailcraftWall.java
@@ -16,6 +16,7 @@ import mods.railcraft.common.plugins.forge.CreativePlugin;
 import mods.railcraft.common.plugins.forge.RailcraftRegistry;
 import mods.railcraft.common.plugins.forge.WorldPlugin;
 import mods.railcraft.common.util.misc.Game;
+import mods.railcraft.common.util.misc.Predicates;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFenceGate;
 import net.minecraft.block.BlockWall;
@@ -148,7 +149,7 @@ public class BlockRailcraftWall extends BlockWall implements IMaterialBlock {
 
     @Override
     public void getSubBlocks(Item item, CreativeTabs tab, List<ItemStack> list) {
-        list.addAll(Materials.getCreativeList().stream().map(this::getStack).collect(Collectors.toList()));
+        list.addAll(Materials.getCreativeList().stream().map(this::getStack).filter(Predicates.nonNull()).collect(Collectors.toList()));
     }
 
     @Nonnull

--- a/src/main/java/mods/railcraft/common/blocks/aesthetics/materials/slab/BlockRailcraftSlab.java
+++ b/src/main/java/mods/railcraft/common/blocks/aesthetics/materials/slab/BlockRailcraftSlab.java
@@ -22,6 +22,7 @@ import mods.railcraft.common.plugins.forge.RailcraftRegistry;
 import mods.railcraft.common.plugins.forge.WorldPlugin;
 import mods.railcraft.common.util.misc.AABBFactory;
 import mods.railcraft.common.util.misc.Game;
+import mods.railcraft.common.util.misc.Predicates;
 import mods.railcraft.common.util.sounds.RailcraftSoundTypes;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
@@ -184,7 +185,7 @@ public class BlockRailcraftSlab extends BlockContainerRailcraft implements IMate
 
     @Override
     public void getSubBlocks(Item item, CreativeTabs tab, List<ItemStack> list) {
-        list.addAll(Materials.getCreativeList().stream().map(this::getStack).collect(Collectors.toList()));
+        list.addAll(Materials.getCreativeList().stream().map(this::getStack).filter(Predicates.nonNull()).collect(Collectors.toList()));
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/blocks/aesthetics/post/BlockPost.java
+++ b/src/main/java/mods/railcraft/common/blocks/aesthetics/post/BlockPost.java
@@ -13,6 +13,7 @@ import mods.railcraft.api.core.IPostConnection;
 import mods.railcraft.api.core.IVariantEnum;
 import mods.railcraft.common.plugins.color.EnumColor;
 import mods.railcraft.common.plugins.forestry.ForestryPlugin;
+import mods.railcraft.common.plugins.forge.CreativePlugin;
 import mods.railcraft.common.plugins.forge.HarvestPlugin;
 import mods.railcraft.common.plugins.forge.RailcraftRegistry;
 import mods.railcraft.common.plugins.forge.WorldPlugin;
@@ -101,7 +102,7 @@ public class BlockPost extends BlockPostBase implements IPostConnection {
     public void getSubBlocks(@Nonnull Item item, CreativeTabs tab, List<ItemStack> list) {
         for (EnumPost post : EnumPost.values()) {
             if (post == EnumPost.EMBLEM) continue;
-            list.add(post.getStack());
+            CreativePlugin.addToList(list, post.getStack());
         }
     }
 

--- a/src/main/java/mods/railcraft/common/blocks/aesthetics/post/BlockPostMetal.java
+++ b/src/main/java/mods/railcraft/common/blocks/aesthetics/post/BlockPostMetal.java
@@ -12,6 +12,7 @@ package mods.railcraft.common.blocks.aesthetics.post;
 import mods.railcraft.api.core.IVariantEnum;
 import mods.railcraft.common.plugins.color.EnumColor;
 import mods.railcraft.common.plugins.forestry.ForestryPlugin;
+import mods.railcraft.common.plugins.forge.CreativePlugin;
 import mods.railcraft.common.plugins.forge.HarvestPlugin;
 import mods.railcraft.common.plugins.forge.RailcraftRegistry;
 import mods.railcraft.common.plugins.forge.WorldPlugin;
@@ -92,7 +93,7 @@ public class BlockPostMetal extends BlockPostBase {
     @Override
     public void getSubBlocks(@Nonnull Item item, CreativeTabs tab, List<ItemStack> list) {
         for (EnumColor color : EnumColor.VALUES) {
-            list.add(getStack(1, color));
+            CreativePlugin.addToList(list, getStack(1, color));
         }
     }
 

--- a/src/main/java/mods/railcraft/common/blocks/detector/BlockDetector.java
+++ b/src/main/java/mods/railcraft/common/blocks/detector/BlockDetector.java
@@ -404,7 +404,7 @@ public class BlockDetector extends BlockContainerRailcraftSubtyped<EnumDetector>
     public void getSubBlocks(@Nonnull Item item, CreativeTabs tab, List<ItemStack> list) {
         for (EnumDetector detector : EnumDetector.VALUES) {
             if (detector.isEnabled())
-                list.add(detector.getStack());
+                CreativePlugin.addToList(list, detector.getStack());
         }
     }
 }

--- a/src/main/java/mods/railcraft/common/blocks/machine/BlockMachine.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/BlockMachine.java
@@ -23,6 +23,7 @@ import mods.railcraft.common.plugins.forge.HarvestPlugin;
 import mods.railcraft.common.plugins.forge.PowerPlugin;
 import mods.railcraft.common.plugins.forge.WorldPlugin;
 import mods.railcraft.common.util.misc.Game;
+import mods.railcraft.common.util.misc.Predicates;
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
@@ -353,6 +354,7 @@ public class BlockMachine<V extends Enum<V> & IEnumMachine<V>> extends BlockCont
                 getCreativeList().stream()
                         .filter(m -> m.isAvailable())
                         .map(m -> m.getStack())
+                        .filter(Predicates.nonNull())
                         .collect(Collectors.toList())
         );
     }

--- a/src/main/java/mods/railcraft/common/blocks/tracks/outfitted/BlockTrackOutfitted.java
+++ b/src/main/java/mods/railcraft/common/blocks/tracks/outfitted/BlockTrackOutfitted.java
@@ -180,7 +180,7 @@ public class BlockTrackOutfitted extends BlockTrackTile implements IPostConnecti
     @Override
     public void getSubBlocks(Item item, CreativeTabs tab, List<ItemStack> list) {
         for (Tuple<TrackType, TrackKit> combination : TrackRegistry.getCombinations()) {
-            list.add(combination.getSecond().getOutfittedTrack(combination.getFirst()));
+            CreativePlugin.addToList(list, combination.getSecond().getOutfittedTrack(combination.getFirst()));
         }
     }
 

--- a/src/main/java/mods/railcraft/common/blocks/tracks/outfitted/ItemTrackKit.java
+++ b/src/main/java/mods/railcraft/common/blocks/tracks/outfitted/ItemTrackKit.java
@@ -25,6 +25,7 @@ import mods.railcraft.common.plugins.forge.ChatPlugin;
 import mods.railcraft.common.plugins.forge.LocalizationPlugin;
 import mods.railcraft.common.plugins.forge.WorldPlugin;
 import mods.railcraft.common.util.misc.Game;
+import mods.railcraft.common.util.misc.Predicates;
 import mods.railcraft.common.util.sounds.SoundHelper;
 import net.minecraft.block.BlockRailBase;
 import net.minecraft.block.state.IBlockState;
@@ -114,7 +115,7 @@ public class ItemTrackKit extends ItemRailcraft {
     @Override
     public void getSubItems(Item item, CreativeTabs tab, List<ItemStack> list) {
         Map<String, TrackKit> trackKits = TrackRegistry.TRACK_KIT.getVariants();
-        list.addAll(trackKits.values().stream().filter(TrackKit::isVisible).map(this::getStack).collect(Collectors.toList()));
+        list.addAll(trackKits.values().stream().filter(TrackKit::isVisible).map(this::getStack).filter(Predicates.nonNull()).collect(Collectors.toList()));
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/blocks/wayobjects/BlockWayObjectRailcraft.java
+++ b/src/main/java/mods/railcraft/common/blocks/wayobjects/BlockWayObjectRailcraft.java
@@ -15,6 +15,7 @@ import mods.railcraft.common.core.RailcraftConfig;
 import mods.railcraft.common.items.ItemCircuit;
 import mods.railcraft.common.items.RailcraftItems;
 import mods.railcraft.common.plugins.forge.CraftingPlugin;
+import mods.railcraft.common.plugins.forge.CreativePlugin;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
@@ -163,7 +164,7 @@ public class BlockWayObjectRailcraft extends BlockWayObject {
     public void getSubBlocks(Item item, CreativeTabs tab, List<ItemStack> list) {
         for (EnumWayObject type : EnumWayObject.getCreativeList()) {
             if (type.isEnabled())
-                list.add(type.getItem());
+                CreativePlugin.addToList(list, type.getItem());
         }
     }
 

--- a/src/main/java/mods/railcraft/common/carts/ItemLocomotive.java
+++ b/src/main/java/mods/railcraft/common/carts/ItemLocomotive.java
@@ -17,6 +17,7 @@ import mods.railcraft.client.emblems.EmblemToolsClient;
 import mods.railcraft.common.plugins.color.ColorPlugin;
 import mods.railcraft.common.plugins.color.EnumColor;
 import mods.railcraft.common.plugins.forge.CraftingPlugin;
+import mods.railcraft.common.plugins.forge.CreativePlugin;
 import mods.railcraft.common.plugins.forge.LocalizationPlugin;
 import mods.railcraft.common.plugins.forge.PlayerPlugin;
 import mods.railcraft.common.util.inventory.InvTools;
@@ -66,7 +67,7 @@ public class ItemLocomotive extends ItemCart implements ColorPlugin.IColoredItem
     @Override
     public void getSubItems(Item item, CreativeTabs tab, List<ItemStack> list) {
         for (String skin : renderType.getRendererTags()) {
-            list.add(renderType.getItemWithRenderer(skin, new ItemStack(this)));
+            CreativePlugin.addToList(list, renderType.getItemWithRenderer(skin, new ItemStack(this)));
         }
     }
 

--- a/src/main/java/mods/railcraft/common/items/ItemRailcraftSubtyped.java
+++ b/src/main/java/mods/railcraft/common/items/ItemRailcraftSubtyped.java
@@ -12,6 +12,7 @@ package mods.railcraft.common.items;
 
 import mods.railcraft.api.core.IVariantEnum;
 import mods.railcraft.common.core.RailcraftConstants;
+import mods.railcraft.common.plugins.forge.CreativePlugin;
 import mods.railcraft.common.plugins.forge.LocalizationPlugin;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
@@ -53,10 +54,10 @@ public class ItemRailcraftSubtyped extends ItemRailcraft {
         IVariantEnum[] variants = getVariants();
         if (variants != null) {
             for (IVariantEnum variant : variants) {
-                list.add(getStack(variant));
+                CreativePlugin.addToList(list, getStack(variant));
             }
         } else {
-            list.add(getStack(null));
+            CreativePlugin.addToList(list, getStack(null));
         }
     }
 

--- a/src/main/java/mods/railcraft/common/plugins/forge/CreativePlugin.java
+++ b/src/main/java/mods/railcraft/common/plugins/forge/CreativePlugin.java
@@ -16,7 +16,10 @@ import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
+import java.util.List;
 import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
 
 /**
  * @author CovertJaguar <http://www.railcraft.info>
@@ -49,5 +52,17 @@ public class CreativePlugin {
             return tabItem.get().getItem();
         }
 
+    }
+
+    public static void addToList(List<ItemStack> creativeList, @Nullable ItemStack stack) {
+        if (stack != null) {
+            creativeList.add(stack);
+        }
+    }
+
+    public static void addToList(List<ItemStack> creativeList, ItemStack... stacks) {
+        for (ItemStack stack : stacks)
+            if (stack != null)
+                creativeList.add(stack);
     }
 }

--- a/src/main/java/mods/railcraft/common/util/misc/Predicates.java
+++ b/src/main/java/mods/railcraft/common/util/misc/Predicates.java
@@ -15,6 +15,7 @@ import mods.railcraft.common.util.collections.StackKey;
 import net.minecraft.item.ItemStack;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -24,7 +25,13 @@ import java.util.function.Predicate;
  *
  * @author CovertJaguar <http://www.railcraft.info>
  */
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class Predicates {
+
+    private static final Predicate NON_NULL = Objects::nonNull;
+    private static final Predicate ALWAYS_FALSE = t -> false;
+    private static final Predicate ALWAYS_TRUE = t -> true;
+
     public static <T> Predicate<T> instanceOf(Class<? extends T> clazz) {
         return clazz::isInstance;
     }
@@ -44,14 +51,14 @@ public class Predicates {
     }
 
     public static <T> Predicate<T> alwaysTrue() {
-        return t -> true;
+        return ALWAYS_TRUE;
     }
 
     public static <T> Predicate<T> alwaysFalse() {
-        return t -> false;
+        return ALWAYS_FALSE;
     }
 
     public static <T> Predicate<T> nonNull() {
-        return t -> t != null;
+        return NON_NULL;
     }
 }


### PR DESCRIPTION
Fixed #1171 after the second commit. Before the game instantly crashes when you click that search tab. Now there is no effect, although loot table warns for missing items when the signal module is disabled (does not crash game)