### PR TITLE
Do a block type check before using destruction

### DIFF
--- a/src/main/java/mods/railcraft/common/items/ItemCrowbar.java
+++ b/src/main/java/mods/railcraft/common/items/ItemCrowbar.java
@@ -152,7 +152,7 @@ public abstract class ItemCrowbar extends ItemTool implements IToolCrowbar, IBox
                 if (!player.isSneaking()) {
                     int level = RailcraftEnchantments.DESTRUCTION.getLevel(stack) * 2 + 1;
                     if (level > 1)
-                        checkBlocks(world, level, pos, player);
+                        checkBlock(world, level, pos, player);
                 }
             }
         return super.onBlockDestroyed(stack, world, state, pos, entityLiving);


### PR DESCRIPTION
Fixes #1223. Breaking long grass no longer break adjacent tracks.