### PR TITLE
Various worldspike fixes

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/machine/worldspike/BlockWorldspikePoint.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/worldspike/BlockWorldspikePoint.java
@@ -54,21 +54,22 @@ public class BlockWorldspikePoint extends BlockRailcraft {
             if (crowbar.canWhack(player, hand, heldItem, pos)) {
                 WorldCoordinate ourCoord = new WorldCoordinate(world.provider.getDimension(), pos);
                 WorldCoordinate target = TileWorldspike.getTarget(player);
-                if (target == null)
-                    TileWorldspike.setTarget(ourCoord, player, getUnlocalizedName());
-                else if (world.provider.getDimension() != target.getDim())
-                    ChatPlugin.sendLocalizedChatFromServer(player, "gui.railcraft.worldspike.pair.fail.dimension", getUnlocalizedName());
-                else if (ourCoord.equals(target)) {
-                    TileWorldspike.removeTarget(player);
-                    ChatPlugin.sendLocalizedChatFromServer(player, "gui.railcraft.worldspike.pair.cancel", getUnlocalizedName());
+                if (target == null) {
+                    TileWorldspike.setTarget(ourCoord, player, getLocalizedName());
                 } else {
-                    if (TileWorldspike.isTargetLoaded(player, target, getUnlocalizedName())) {
+                    if (world.provider.getDimension() != target.getDim()) {
+                        ChatPlugin.sendLocalizedChatFromServer(player, "gui.railcraft.worldspike.pair.fail.dimension", getLocalizedName());
+                    } else if (ourCoord.equals(target)) {
+                        ChatPlugin.sendLocalizedChatFromServer(player, "gui.railcraft.worldspike.pair.cancel", getLocalizedName());
+                    } else if (TileWorldspike.isTargetLoaded(player, target, getLocalizedName())) {
                         TileEntity tile = WorldPlugin.getBlockTile(world, target.getPos());
-                        if (tile instanceof TileWorldspike)
+                        if (tile instanceof TileWorldspike) {
                             ((TileWorldspike) tile).setPoint(player, ourCoord);
-                        else if (tile != null)
-                            ChatPlugin.sendLocalizedChatFromServer(player, "gui.railcraft.worldspike.pair.fail.invalid", getUnlocalizedName());
+                        } else {
+                            ChatPlugin.sendLocalizedChatFromServer(player, "gui.railcraft.worldspike.pair.fail.invalid", getLocalizedName());
+                        }
                     }
+                    TileWorldspike.removeTarget(player);
                 }
                 crowbar.onWhack(player, hand, heldItem, pos);
                 return true;
@@ -86,6 +87,11 @@ public class BlockWorldspikePoint extends BlockRailcraft {
     public float getExplosionResistance(World world, BlockPos pos, Entity exploder, Explosion explosion) {
 //        return 60f * 3f / 5f;
         return 90f;
+    }
+
+    @Override
+    public boolean isOpaqueCube(IBlockState state) {
+        return false;
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/blocks/machine/worldspike/TileWorldspike.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/worldspike/TileWorldspike.java
@@ -96,15 +96,18 @@ public class TileWorldspike extends TileMachineItem implements IWorldspike, ISid
                 if (Game.isHost(worldObj)) {
                     WorldCoordinate ourCoord = new WorldCoordinate(this);
                     WorldCoordinate target = pointPairingMap.get(player);
-                    if (target == null)
+                    if (target == null) {
                         setTarget(ourCoord, player, getLocalizationTag());
-                    else if (worldObj.provider.getDimension() != target.getDim())
-                        ChatPlugin.sendLocalizedChatFromServer(player, "gui.railcraft.worldspike.pair.fail.dimension", getLocalizationTag());
-                    else if (Objects.equals(ourCoord, target)) {
+                    } else {
+                        if (worldObj.provider.getDimension() != target.getDim()) {
+                            ChatPlugin.sendLocalizedChatFromServer(player, "gui.railcraft.worldspike.pair.fail.dimension", getLocalizationTag());
+                        } else if (Objects.equals(ourCoord, target)) {
+                            ChatPlugin.sendLocalizedChatFromServer(player, "gui.railcraft.worldspike.pair.cancel", getLocalizationTag());
+                        } else {
+                            setPoint(player, target);
+                        }
                         removeTarget(player);
-                        ChatPlugin.sendLocalizedChatFromServer(player, "gui.railcraft.worldspike.pair.cancel", getLocalizationTag());
-                    } else
-                        setPoint(player, target);
+                    }
                     crowbar.onWhack(player, hand, heldItem, getPos());
                 }
                 return true;
@@ -165,13 +168,13 @@ public class TileWorldspike extends TileMachineItem implements IWorldspike, ISid
             int zPointChunk = coord.getZ() >> 4;
 
             if (xChunk != xPointChunk && zChunk != zPointChunk) {
-                ChatPlugin.sendLocalizedChatFromServer(player, "gui.railcraft.worldspike.pair.fail.alignment", getLocalizationTag(), state.getBlock().getUnlocalizedName());
+                ChatPlugin.sendLocalizedChatFromServer(player, "gui.railcraft.worldspike.pair.fail.alignment", getLocalizationTag(), state.getBlock().getLocalizedName());
                 return false;
             }
 
             int max = getMaxPointChunks();
             if (Math.abs(xChunk - xPointChunk) >= max || Math.abs(zChunk - zPointChunk) >= max) {
-                ChatPlugin.sendLocalizedChatFromServer(player, "gui.railcraft.worldspike.pair.fail.distance", getLocalizationTag(), state.getBlock().getUnlocalizedName());
+                ChatPlugin.sendLocalizedChatFromServer(player, "gui.railcraft.worldspike.pair.fail.distance", getLocalizationTag(), state.getBlock().getLocalizedName());
                 return false;
             }
 


### PR DESCRIPTION
Fixes #1258
Fixes #847 - Always clean up when failing to pair. Now missing ones will
be said to be "invalid"
Also fixed localized name of worldspike points.