### PR TITLE
Let charge blocks use existing battery

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/RailcraftTileEntity.java
+++ b/src/main/java/mods/railcraft/common/blocks/RailcraftTileEntity.java
@@ -266,4 +266,8 @@ public abstract class RailcraftTileEntity extends TileEntity implements INetwork
         return hasCustomName() ? new TextComponentString(customName) : new TextComponentTranslation(getLocalizationTag());
     }
 
+    @Override
+    protected void setWorldCreate(World worldIn) {
+        setWorldObj(worldIn);
+    }
 }

--- a/src/main/java/mods/railcraft/common/blocks/charge/ChargeNetwork.java
+++ b/src/main/java/mods/railcraft/common/blocks/charge/ChargeNetwork.java
@@ -27,6 +27,7 @@ import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * Created by CovertJaguar on 7/23/2016 for Railcraft.
@@ -35,10 +36,10 @@ import java.util.function.Predicate;
  */
 public class ChargeNetwork {
     private final ChargeGraph NULL_GRAPH = new NullGraph();
-    public final Map<BlockPos, ChargeNode> chargeNodes = new HashMap<>();
-    public final Map<BlockPos, ChargeNode> chargeQueue = new LinkedHashMap<>();
-    public final Set<ChargeNode> tickingNodes = new LinkedHashSet<>();
-    public final Set<ChargeGraph> chargeGraphs = Collections.newSetFromMap(new WeakHashMap<>());
+    private final Map<BlockPos, ChargeNode> chargeNodes = new HashMap<>();
+    private final Map<BlockPos, ChargeNode> chargeQueue = new LinkedHashMap<>();
+    private final Set<ChargeNode> tickingNodes = new LinkedHashSet<>();
+    private final Set<ChargeGraph> chargeGraphs = Collections.newSetFromMap(new WeakHashMap<>());
     private final ChargeNode NULL_NODE = new NullNode();
     private final WeakReference<World> world;
     private final BatterySaveData batterySaveData;
@@ -189,9 +190,20 @@ public class ChargeNetwork {
         return node;
     }
 
+    public ChargeNode getNodeSafe(BlockPos pos) {
+        ChargeNode node = chargeNodes.get(pos);
+        return node == null ? NULL_NODE : node;
+    }
+
     public boolean nodeMatches(BlockPos pos, IChargeBlock.ChargeDef chargeDef) {
         ChargeNode node = chargeNodes.get(pos);
         return node != null && !node.isNull() && !node.invalid && node.chargeDef == chargeDef;
+    }
+
+    public IChargeBlock.ChargeBattery getTileBattery(BlockPos pos, Supplier<IChargeBlock.ChargeBattery> supplier) {
+        ChargeNetwork.ChargeNode node = chargeNodes.get(pos);
+        IChargeBlock.ChargeBattery battery = node == null ? null : node.getBattery();
+        return battery == null ? supplier.get() : battery;
     }
 
     public class ChargeGraph extends ForwardingSet<ChargeNode> {

--- a/src/main/java/mods/railcraft/common/blocks/machine/charge/TileCharge.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/charge/TileCharge.java
@@ -10,6 +10,7 @@
 package mods.railcraft.common.blocks.machine.charge;
 
 import mods.railcraft.common.blocks.charge.ChargeManager;
+import mods.railcraft.common.blocks.charge.ChargeNetwork;
 import mods.railcraft.common.blocks.charge.IChargeBlock;
 import mods.railcraft.common.blocks.machine.TileMachineBase;
 import net.minecraft.block.Block;
@@ -17,19 +18,27 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-import javax.annotation.Nullable;
 import java.util.List;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author CovertJaguar <http://www.railcraft.info>
  */
 public abstract class TileCharge extends TileMachineBase {
-    @Nullable
+
     public abstract IChargeBlock.ChargeBattery getChargeBattery();
 
     private int prevComparatorOutput;
 
     public void neighborChanged(IBlockState state, World worldIn, BlockPos pos, Block blockIn) {
+    }
+
+    protected IChargeBlock.ChargeBattery retrieve(Supplier<IChargeBlock.ChargeBattery> supplier) {
+        ChargeNetwork.ChargeNode node = ChargeManager.getNetwork(worldObj).chargeNodes.get(pos);
+        IChargeBlock.ChargeBattery battery = node == null ? null : node.getBattery();
+        return battery == null ? supplier.get() : battery;
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/blocks/machine/charge/TileCharge.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/charge/TileCharge.java
@@ -10,7 +10,6 @@
 package mods.railcraft.common.blocks.machine.charge;
 
 import mods.railcraft.common.blocks.charge.ChargeManager;
-import mods.railcraft.common.blocks.charge.ChargeNetwork;
 import mods.railcraft.common.blocks.charge.IChargeBlock;
 import mods.railcraft.common.blocks.machine.TileMachineBase;
 import net.minecraft.block.Block;
@@ -19,9 +18,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import java.util.List;
-import java.util.function.Supplier;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author CovertJaguar <http://www.railcraft.info>
@@ -33,12 +29,6 @@ public abstract class TileCharge extends TileMachineBase {
     private int prevComparatorOutput;
 
     public void neighborChanged(IBlockState state, World worldIn, BlockPos pos, Block blockIn) {
-    }
-
-    protected IChargeBlock.ChargeBattery retrieve(Supplier<IChargeBlock.ChargeBattery> supplier) {
-        ChargeNetwork.ChargeNode node = ChargeManager.getNetwork(worldObj).chargeNodes.get(pos);
-        IChargeBlock.ChargeBattery battery = node == null ? null : node.getBattery();
-        return battery == null ? supplier.get() : battery;
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/blocks/machine/charge/TileChargeFeederAdmin.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/charge/TileChargeFeederAdmin.java
@@ -9,6 +9,7 @@
  -----------------------------------------------------------------------------*/
 package mods.railcraft.common.blocks.machine.charge;
 
+import mods.railcraft.common.blocks.charge.ChargeManager;
 import mods.railcraft.common.blocks.charge.IChargeBlock;
 import mods.railcraft.common.blocks.machine.IEnumMachine;
 import net.minecraft.block.Block;
@@ -65,7 +66,7 @@ public class TileChargeFeederAdmin extends TileCharge {
     @Override
     public InfiniteBattery getChargeBattery() {
         if (chargeBattery == null) {
-            chargeBattery = (InfiniteBattery) retrieve(InfiniteBattery::new);
+            chargeBattery = (InfiniteBattery) ChargeManager.getNetwork(worldObj).getTileBattery(pos, () -> new IChargeBlock.ChargeBattery(1024.0, 512.0, 0.65));;
         }
         return chargeBattery;
     }

--- a/src/main/java/mods/railcraft/common/blocks/machine/charge/TileChargeFeederAdmin.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/charge/TileChargeFeederAdmin.java
@@ -27,7 +27,8 @@ import java.util.List;
  * @author CovertJaguar <http://www.railcraft.info>
  */
 public class TileChargeFeederAdmin extends TileCharge {
-    public final InfiniteBattery chargeBattery = new InfiniteBattery();
+    @Nullable
+    public InfiniteBattery chargeBattery;
 
     private static class InfiniteBattery extends IChargeBlock.ChargeBattery {
         private boolean enabled;
@@ -62,7 +63,10 @@ public class TileChargeFeederAdmin extends TileCharge {
     }
 
     @Override
-    public IChargeBlock.ChargeBattery getChargeBattery() {
+    public InfiniteBattery getChargeBattery() {
+        if (chargeBattery == null) {
+            chargeBattery = (InfiniteBattery) retrieve(InfiniteBattery::new);
+        }
         return chargeBattery;
     }
 
@@ -74,24 +78,24 @@ public class TileChargeFeederAdmin extends TileCharge {
     @Override
     public void onBlockPlacedBy(IBlockState state, @Nullable EntityLivingBase placer, ItemStack stack) {
         super.onBlockPlacedBy(state, placer, stack);
-        chargeBattery.enabled = state.getValue(BlockChargeFeeder.REDSTONE);
+        getChargeBattery().enabled = state.getValue(BlockChargeFeeder.REDSTONE);
     }
 
     @Override
     public void neighborChanged(IBlockState state, World worldIn, BlockPos pos, Block blockIn) {
-        chargeBattery.enabled = state.getValue(BlockChargeFeeder.REDSTONE);
+        getChargeBattery().enabled = state.getValue(BlockChargeFeeder.REDSTONE);
     }
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
         super.writeToNBT(nbt);
-        nbt.setBoolean("enabled", chargeBattery.enabled);
+        nbt.setBoolean("enabled", getChargeBattery().enabled);
         return nbt;
     }
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
         super.readFromNBT(nbt);
-        chargeBattery.enabled = nbt.getBoolean("enabled");
+        getChargeBattery().enabled = nbt.getBoolean("enabled");
     }
 }

--- a/src/main/java/mods/railcraft/common/blocks/machine/charge/TileChargeFeederIC2.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/charge/TileChargeFeederIC2.java
@@ -9,6 +9,7 @@
  -----------------------------------------------------------------------------*/
 package mods.railcraft.common.blocks.machine.charge;
 
+import mods.railcraft.common.blocks.charge.ChargeManager;
 import mods.railcraft.common.blocks.charge.IChargeBlock;
 import mods.railcraft.common.blocks.machine.IEnumMachine;
 import mods.railcraft.common.plugins.ic2.IC2Plugin;
@@ -39,7 +40,7 @@ public class TileChargeFeederIC2 extends TileCharge implements ISinkDelegate {
     @Override
     public IChargeBlock.ChargeBattery getChargeBattery() {
         if (chargeBattery == null) {
-            chargeBattery = retrieve(() -> new IChargeBlock.ChargeBattery(1024.0, 512.0, 0.65));
+            chargeBattery = ChargeManager.getNetwork(worldObj).getTileBattery(pos, () -> new IChargeBlock.ChargeBattery(1024.0, 512.0, 0.65));
         }
         return chargeBattery;
     }

--- a/src/main/java/mods/railcraft/common/blocks/machine/charge/TileChargeFeederIC2.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/charge/TileChargeFeederIC2.java
@@ -20,13 +20,16 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 
+import javax.annotation.Nullable;
+
 /**
  * @author CovertJaguar <http://www.railcraft.info>
  */
 public class TileChargeFeederIC2 extends TileCharge implements ISinkDelegate {
     private TileEntity sinkDelegate;
     private boolean addedToIC2EnergyNet;
-    public final IChargeBlock.ChargeBattery chargeBattery = new IChargeBlock.ChargeBattery(1024.0, 512.0, 0.65);
+    @Nullable
+    private IChargeBlock.ChargeBattery chargeBattery;
 
     @Override
     public IEnumMachine<?> getMachineType() {
@@ -35,6 +38,9 @@ public class TileChargeFeederIC2 extends TileCharge implements ISinkDelegate {
 
     @Override
     public IChargeBlock.ChargeBattery getChargeBattery() {
+        if (chargeBattery == null) {
+            chargeBattery = retrieve(() -> new IChargeBlock.ChargeBattery(1024.0, 512.0, 0.65));
+        }
         return chargeBattery;
     }
 
@@ -71,8 +77,8 @@ public class TileChargeFeederIC2 extends TileCharge implements ISinkDelegate {
     @Override
     public double getDemandedEnergy() {
         IBlockState state = getBlockState();
-        if (state != null && state.getBlock() instanceof BlockChargeFeeder && state.getValue(BlockChargeFeeder.REDSTONE) && chargeBattery.isInitialized()) {
-            double chargeDifference = chargeBattery.getCapacity() - chargeBattery.getCharge();
+        if (state != null && state.getBlock() instanceof BlockChargeFeeder && state.getValue(BlockChargeFeeder.REDSTONE) && getChargeBattery().isInitialized()) {
+            double chargeDifference = getChargeBattery().getCapacity() - getChargeBattery().getCharge();
             return chargeDifference > 0.0 ? chargeDifference : 0.0;
         }
         return 0.0;
@@ -85,7 +91,7 @@ public class TileChargeFeederIC2 extends TileCharge implements ISinkDelegate {
 
     @Override
     public double injectEnergy(EnumFacing directionFrom, double amount) {
-        chargeBattery.addCharge(amount);
+        getChargeBattery().addCharge(amount);
         return 0.0;
     }
 


### PR DESCRIPTION
Fixes #1224
Set world early to prevent errors when NBT is read in admin feeders.