### PR TITLE
Added bed cart

### DIFF
--- a/extras/ide/inspections/net/minecraftforge/event/entity/player/annotations.xml
+++ b/extras/ide/inspections/net/minecraftforge/event/entity/player/annotations.xml
@@ -2,4 +2,7 @@
     <item name='net.minecraftforge.event.entity.player.PlayerDestroyItemEvent net.minecraft.util.EnumHand getHand()'>
         <annotation name='org.jetbrains.annotations.Nullable'/>
     </item>
+    <item name='net.minecraftforge.event.entity.player.PlayerSleepInBedEvent net.minecraft.entity.player.EntityPlayer.SleepResult getResultStatus()'>
+        <annotation name='org.jetbrains.annotations.Nullable'/>
+    </item>
 </root>

--- a/src/main/java/mods/railcraft/client/core/SleepKeyHandler.java
+++ b/src/main/java/mods/railcraft/client/core/SleepKeyHandler.java
@@ -1,0 +1,43 @@
+package mods.railcraft.client.core;
+
+import mods.railcraft.common.core.Railcraft;
+import mods.railcraft.common.util.network.PacketBuilder;
+import mods.railcraft.common.util.network.PacketKeyPress;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.settings.KeyBinding;
+import net.minecraftforge.client.settings.KeyConflictContext;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.client.registry.ClientRegistry;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import org.lwjgl.input.Keyboard;
+
+/**
+ * A key handler for sleeping on bed carts.
+ */
+@SideOnly(Side.CLIENT)
+public final class SleepKeyHandler {
+
+    public static final SleepKeyHandler INSTANCE = new SleepKeyHandler();
+
+    private final KeyBinding sleepKey = new KeyBinding("keybind.railcraft.cart.bed", KeyConflictContext.IN_GAME, Keyboard.KEY_DOWN, Railcraft.NAME);
+
+    private SleepKeyHandler() {
+    }
+
+    public void init() {
+        ClientRegistry.registerKeyBinding(sleepKey);
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onClientTick(TickEvent.ClientTickEvent event) {
+        if (Minecraft.getMinecraft().theWorld == null)
+            return;
+        if (sleepKey.isPressed()) {
+            PacketBuilder.instance().sendKeyPressPacket(PacketKeyPress.EnumKeyBinding.BED_CART_SLEEP);
+        }
+    }
+}

--- a/src/main/java/mods/railcraft/common/carts/EntityCartBed.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityCartBed.java
@@ -197,6 +197,12 @@ public class EntityCartBed extends EntityCartBasic {
         shouldSleep = true;
     }
 
+    @Override
+    public void setDead() {
+        super.setDead();
+        MinecraftForge.EVENT_BUS.unregister(this);
+    }
+
     @Nullable
     protected Entity getFirstPassenger() {
         List<Entity> passengers = getPassengers();

--- a/src/main/java/mods/railcraft/common/carts/EntityCartBed.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityCartBed.java
@@ -1,0 +1,205 @@
+package mods.railcraft.common.carts;
+
+import mods.railcraft.common.plugins.forge.ChatPlugin;
+import mods.railcraft.common.util.misc.AABBFactory;
+import mods.railcraft.common.util.misc.Game;
+import net.minecraft.block.BlockBed;
+import net.minecraft.block.BlockHorizontal;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.monster.EntityMob;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.init.Blocks;
+import net.minecraft.network.play.server.SPacketSetPassengers;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerSleepInBedEvent;
+import net.minecraftforge.event.entity.player.PlayerWakeUpEvent;
+import net.minecraftforge.event.entity.player.SleepingLocationCheckEvent;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.ReflectionHelper;
+
+import javax.annotation.Nullable;
+import java.lang.ref.WeakReference;
+import java.util.List;
+
+/**
+ *
+ */
+public class EntityCartBed extends EntityCartBasic {
+
+    private WeakReference<EntityPlayer> lastSleeper = new WeakReference<>(null);
+    private boolean wokeUp = false;
+    private boolean rideAfterSleep = false;
+    private boolean shouldSleep = false;
+
+    @SuppressWarnings("unused")
+    public EntityCartBed(World world) {
+        super(world);
+    }
+
+    @SuppressWarnings("unused")
+    public EntityCartBed(World world, double x, double y, double z) {
+        super(world, x, y, z);
+    }
+
+    {
+        if (Game.isHost(worldObj))
+            MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @Override
+    public IRailcraftCartContainer getCartType() {
+        return RailcraftCarts.BED;
+    }
+
+    @Override
+    public boolean canBeRidden() {
+        return true;
+    }
+
+    @Override
+    public IBlockState getDefaultDisplayTile() {
+        return Blocks.BED.getDefaultState().withProperty(BlockBed.PART, BlockBed.EnumPartType.HEAD)
+                .withProperty(BlockHorizontal.FACING, EnumFacing.SOUTH);
+    }
+
+    @Override
+    public void onUpdate() {
+        super.onUpdate();
+        if (Game.isClient(worldObj)) {
+            return;
+        }
+
+        EntityPlayer sleeper = lastSleeper.get();
+        if (sleeper != null) {
+            if (sleeper.getRidingEntity() != this)
+                sleeper.startRiding(this, true);
+            // Riding enforced! Otherwise player dismounts once sleeps
+            if (rideAfterSleep)
+                sendPlayerRiding((EntityPlayerMP) sleeper);
+            if (!wokeUp) {
+                sleeper.playerLocation = getPosition();
+                return;
+            }
+            wokeUp = false;
+            lastSleeper = new WeakReference<>(null);
+        }
+
+        Entity rider = getFirstPassenger();
+        if (!(rider instanceof EntityPlayer))
+            return;
+        EntityPlayer player = (EntityPlayer) rider;
+
+        if (shouldSleep && worldObj.provider.isSurfaceWorld() && !player.isPlayerSleeping()) {
+            shouldSleep = false;
+            EntityPlayer.SleepResult sleepResult = player.trySleep(getPosition());
+            if (sleepResult == EntityPlayer.SleepResult.NOT_SAFE) {
+                ChatPlugin.sendLocalizedChatFromServer(player, "tile.bed.notSafe");
+            } else if (sleepResult == EntityPlayer.SleepResult.NOT_POSSIBLE_NOW) {
+                ChatPlugin.sendLocalizedChatFromServer(player, "tile.bed.noSleep");
+            }
+        }
+    }
+
+    @Override
+    protected void addPassenger(Entity passenger) {
+        super.addPassenger(passenger);
+        if (Game.isHost(worldObj) && passenger instanceof EntityPlayerMP) {
+            ChatPlugin.sendLocalizedChatFromServer((EntityPlayerMP) passenger, "gui.railcraft.cart.bed.key");
+        }
+    }
+
+    @Override
+    public void onActivatorRailPass(int x, int y, int z, boolean receivingPower) {
+        //No rider removal!
+    }
+
+    @SubscribeEvent
+    public void onPlayerSleep(PlayerSleepInBedEvent event) {
+        EntityPlayer player = event.getEntityPlayer();
+        // Hmm, player is most likely right, although we cannot really guarantee yet!
+        if (event.getPos().equals(getPosition()) && player == getFirstPassenger()) {
+            event.setResult(trySleep(player));
+            if (event.getResultStatus() == EntityPlayer.SleepResult.OK) {
+                lastSleeper = new WeakReference<>(player);
+                rideAfterSleep = true;
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public void onLocationCheck(SleepingLocationCheckEvent event) {
+        if (event.getEntityPlayer() == lastSleeper.get()) {
+            event.setResult(Event.Result.ALLOW);
+        }
+    }
+
+    @SubscribeEvent
+    public void onWakeUp(PlayerWakeUpEvent event) {
+        if (event.getEntityPlayer() == lastSleeper.get()) {
+            wokeUp = true;
+        }
+    }
+
+    private EntityPlayer.SleepResult trySleep(EntityPlayer player) {
+        if (player.isPlayerSleeping() || !player.isEntityAlive()) {
+            return EntityPlayer.SleepResult.OTHER_PROBLEM;
+        }
+
+        if (!player.worldObj.provider.isSurfaceWorld()) {
+            return EntityPlayer.SleepResult.NOT_POSSIBLE_HERE;
+        }
+
+        if (player.worldObj.isDaytime()) {
+            return EntityPlayer.SleepResult.NOT_POSSIBLE_NOW;
+        }
+
+        double d0 = 8.0D;
+        double d1 = 5.0D;
+        List<EntityMob> list = player.worldObj.getEntitiesWithinAABB(EntityMob.class,
+                AABBFactory.start()
+                        .fromAABB(player.getEntityBoundingBox())
+                        .expandXAxis(d0)
+                        .expandYAxis(d1)
+                        .expandZAxis(d0)
+                        .build());
+
+        if (!list.isEmpty()) {
+            return EntityPlayer.SleepResult.NOT_SAFE;
+        }
+
+        player.setPosition(posX, posY, posZ);
+
+        startSleeping(player);
+        player.playerLocation = getPosition();
+
+        if (!player.worldObj.isRemote) {
+            player.worldObj.updateAllPlayersSleepingFlag();
+        }
+
+        return EntityPlayer.SleepResult.OK;
+    }
+
+    private static void startSleeping(EntityPlayer player) {
+        ReflectionHelper.setPrivateValue(EntityPlayer.class, player, true, 23);
+        ReflectionHelper.setPrivateValue(EntityPlayer.class, player, 0, 25);
+    }
+
+    private void sendPlayerRiding(EntityPlayerMP player) {
+        player.connection.sendPacket(new SPacketSetPassengers(this));
+    }
+
+    public void attemptSleep() {
+        shouldSleep = true;
+    }
+
+    @Nullable
+    protected Entity getFirstPassenger() {
+        List<Entity> passengers = getPassengers();
+        return passengers.isEmpty() ? null : passengers.get(0);
+    }
+}

--- a/src/main/java/mods/railcraft/common/carts/ItemCartBed.java
+++ b/src/main/java/mods/railcraft/common/carts/ItemCartBed.java
@@ -1,0 +1,32 @@
+package mods.railcraft.common.carts;
+
+import mods.railcraft.client.core.SleepKeyHandler;
+import mods.railcraft.common.plugins.forge.CraftingPlugin;
+import net.minecraft.init.Items;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+/**
+ *
+ */
+public class ItemCartBed extends ItemCart {
+    public ItemCartBed(IRailcraftCartContainer cart) {
+        super(cart);
+    }
+
+    @Override
+    public void defineRecipes() {
+        CraftingPlugin.addRecipe(getStack(),
+                "B",
+                "M",
+                'B', Items.BED,
+                'M', Items.MINECART);
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void initializeClient() {
+        super.initializeClient();
+        SleepKeyHandler.INSTANCE.init();
+    }
+}

--- a/src/main/java/mods/railcraft/common/carts/RailcraftCarts.java
+++ b/src/main/java/mods/railcraft/common/carts/RailcraftCarts.java
@@ -67,6 +67,7 @@ public enum RailcraftCarts implements IRailcraftCartContainer {
     ENERGY_MFSU(1, "cart_ic2_MFSU", EntityCartEnergyMFSU.class, ItemCart::new, ModItems.MFSU::get),
     GIFT(3, "cart_gift", EntityCartGift.class, ItemCartGift::new),
     JUKEBOX(0, "cart_jukebox", EntityCartJukebox.class, ItemCartJukebox::new, from(Blocks.JUKEBOX)),
+    BED(0, "cart_bed", EntityCartBed.class, ItemCartBed::new, from(Blocks.BED)),
     MOW_TRACK_LAYER(1, "mow_track_layer", EntityCartTrackLayer.class, ItemCartMOWTrackLayer::new),
     MOW_TRACK_RELAYER(1, "mow_track_relayer", EntityCartTrackRelayer.class, ItemCartMOWTrackRelayer::new),
     MOW_TRACK_REMOVER(1, "mow_track_remover", EntityCartTrackRemover.class, ItemCartMOWTrackRemover::new),

--- a/src/main/java/mods/railcraft/common/carts/RailcraftCarts.java
+++ b/src/main/java/mods/railcraft/common/carts/RailcraftCarts.java
@@ -67,7 +67,7 @@ public enum RailcraftCarts implements IRailcraftCartContainer {
     ENERGY_MFSU(1, "cart_ic2_MFSU", EntityCartEnergyMFSU.class, ItemCart::new, ModItems.MFSU::get),
     GIFT(3, "cart_gift", EntityCartGift.class, ItemCartGift::new),
     JUKEBOX(0, "cart_jukebox", EntityCartJukebox.class, ItemCartJukebox::new, from(Blocks.JUKEBOX)),
-    BED(0, "cart_bed", EntityCartBed.class, ItemCartBed::new, (c) -> Items.BED),
+    BED(0, "cart_bed", EntityCartBed.class, ItemCartBed::new, () -> new ItemStack(Items.BED)),
     MOW_TRACK_LAYER(1, "mow_track_layer", EntityCartTrackLayer.class, ItemCartMOWTrackLayer::new),
     MOW_TRACK_RELAYER(1, "mow_track_relayer", EntityCartTrackRelayer.class, ItemCartMOWTrackRelayer::new),
     MOW_TRACK_REMOVER(1, "mow_track_remover", EntityCartTrackRemover.class, ItemCartMOWTrackRemover::new),

--- a/src/main/java/mods/railcraft/common/carts/RailcraftCarts.java
+++ b/src/main/java/mods/railcraft/common/carts/RailcraftCarts.java
@@ -67,7 +67,7 @@ public enum RailcraftCarts implements IRailcraftCartContainer {
     ENERGY_MFSU(1, "cart_ic2_MFSU", EntityCartEnergyMFSU.class, ItemCart::new, ModItems.MFSU::get),
     GIFT(3, "cart_gift", EntityCartGift.class, ItemCartGift::new),
     JUKEBOX(0, "cart_jukebox", EntityCartJukebox.class, ItemCartJukebox::new, from(Blocks.JUKEBOX)),
-    BED(0, "cart_bed", EntityCartBed.class, ItemCartBed::new, from(Items.BED)),
+    BED(0, "cart_bed", EntityCartBed.class, ItemCartBed::new, (c) -> Items.BED),
     MOW_TRACK_LAYER(1, "mow_track_layer", EntityCartTrackLayer.class, ItemCartMOWTrackLayer::new),
     MOW_TRACK_RELAYER(1, "mow_track_relayer", EntityCartTrackRelayer.class, ItemCartMOWTrackRelayer::new),
     MOW_TRACK_REMOVER(1, "mow_track_remover", EntityCartTrackRemover.class, ItemCartMOWTrackRemover::new),

--- a/src/main/java/mods/railcraft/common/carts/RailcraftCarts.java
+++ b/src/main/java/mods/railcraft/common/carts/RailcraftCarts.java
@@ -67,7 +67,7 @@ public enum RailcraftCarts implements IRailcraftCartContainer {
     ENERGY_MFSU(1, "cart_ic2_MFSU", EntityCartEnergyMFSU.class, ItemCart::new, ModItems.MFSU::get),
     GIFT(3, "cart_gift", EntityCartGift.class, ItemCartGift::new),
     JUKEBOX(0, "cart_jukebox", EntityCartJukebox.class, ItemCartJukebox::new, from(Blocks.JUKEBOX)),
-    BED(0, "cart_bed", EntityCartBed.class, ItemCartBed::new, from(Blocks.BED)),
+    BED(0, "cart_bed", EntityCartBed.class, ItemCartBed::new, from(Items.BED)),
     MOW_TRACK_LAYER(1, "mow_track_layer", EntityCartTrackLayer.class, ItemCartMOWTrackLayer::new),
     MOW_TRACK_RELAYER(1, "mow_track_relayer", EntityCartTrackRelayer.class, ItemCartMOWTrackRelayer::new),
     MOW_TRACK_REMOVER(1, "mow_track_remover", EntityCartTrackRemover.class, ItemCartMOWTrackRemover::new),

--- a/src/main/java/mods/railcraft/common/modules/ModuleExtras.java
+++ b/src/main/java/mods/railcraft/common/modules/ModuleExtras.java
@@ -26,6 +26,7 @@ public class ModuleExtras extends RailcraftModulePayload {
                         RailcraftCarts.TNT_WOOD,
                         RailcraftCarts.WORK,
                         RailcraftCarts.JUKEBOX,
+                        RailcraftCarts.BED,
                         RailcraftBlocks.TRACK_ELEVATOR,
                         RailcraftBlocks.LOGBOOK
                 );

--- a/src/main/java/mods/railcraft/common/util/misc/EntityIDs.java
+++ b/src/main/java/mods/railcraft/common/util/misc/EntityIDs.java
@@ -34,6 +34,7 @@ public class EntityIDs {
     public static final int CART_TNT_WOOD = 28;
     public static final int CART_WORK = 29;
     public static final int CART_JUKEBOX = 30;
+    public static final int CART_BED = 31;
 
     public static final int LOCOMOTIVE_STEAM_SOLID = 40;
     public static final int LOCOMOTIVE_STEAM_MAGIC = 41;

--- a/src/main/java/mods/railcraft/common/util/network/PacketKeyPress.java
+++ b/src/main/java/mods/railcraft/common/util/network/PacketKeyPress.java
@@ -9,8 +9,10 @@
  -----------------------------------------------------------------------------*/
 package mods.railcraft.common.util.network;
 
+import mods.railcraft.common.carts.EntityCartBed;
 import mods.railcraft.common.carts.EntityLocomotive;
 import mods.railcraft.common.carts.Train;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityMinecart;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -29,7 +31,8 @@ public class PacketKeyPress extends RailcraftPacket {
         LOCOMOTIVE_INCREASE_SPEED,
         LOCOMOTIVE_DECREASE_SPEED,
         LOCOMOTIVE_MODE_CHANGE,
-        LOCOMOTIVE_WHISTLE;
+        LOCOMOTIVE_WHISTLE,
+        BED_CART_SLEEP;
         public static final EnumKeyBinding[] VALUES = values();
     }
 
@@ -74,6 +77,12 @@ public class PacketKeyPress extends RailcraftPacket {
                 break;
             case LOCOMOTIVE_WHISTLE:
                 applyAction(player, true, EntityLocomotive::whistle);
+                break;
+            case BED_CART_SLEEP:
+                Entity ridden = player.getRidingEntity();
+                if (ridden instanceof EntityCartBed) {
+                    ((EntityCartBed) ridden).attemptSleep();
+                }
                 break;
         }
     }

--- a/src/main/resources/assets/railcraft/models/item/cart_bed.json
+++ b/src/main/resources/assets/railcraft/models/item/cart_bed.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "railcraft:items/cart_bed"
+  }
+}


### PR DESCRIPTION
Closes #779.
Sleeper means ties in en_GB, so I call the cart a bed cart.
Needs textures from CovertJaguar. You may do some change in rendering later, too.
Right now, the cart has no item texture. Its cart block is a head part of a bed.
Anything else works well.
When a player hits the sleep key, he will receive message or sleep successfully if he should.
Every cart listens to the sleep events. I hope that it would not cause too much issues with performance.