### PR TITLE
[1.12.2] Fix Command track message with position

### DIFF
--- a/src/main/java/mods/railcraft/common/commands/ArgDeque.java
+++ b/src/main/java/mods/railcraft/common/commands/ArgDeque.java
@@ -15,6 +15,7 @@ import net.minecraft.command.CommandException;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 
 /**
  * Created by CovertJaguar on 6/4/2017 for Railcraft.
@@ -45,8 +46,9 @@ public class ArgDeque extends ArrayDeque<String> {
         if (entries > size())
             throw new CommandException("commands.generic.syntax");
         String[] args = new String[entries];
+        Iterator<String> it = iterator();
         for (int i = 0; i < args.length; i++) {
-            args[i] = peek();
+            args[i] = it.next();
         }
         return args;
     }


### PR DESCRIPTION
Command `/railcraft track message <x> <y> <z> <JSON>` could not run correctly.
After the command, it will try to find the block with (x,x,x) rather than (x,y,z).

To find the cause, `peekArray` uses `peek` to get the element in args, but `peek` will **ALWAYS** return the first element.

The fix can be shown in the commit, I use iterator instead.