### PR TITLE
[1.12.2] Fix crash on Block Register

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/BlockRailcraftSubtyped.java
+++ b/src/main/java/mods/railcraft/common/blocks/BlockRailcraftSubtyped.java
@@ -48,7 +48,7 @@ public abstract class BlockRailcraftSubtyped<V extends Enum<V> & IVariantEnum> e
 
     protected BlockRailcraftSubtyped(Material material, MapColor mapColor) {
         super(material, mapColor);
-        setup();
+        //setup();//This 'setup' is called after 'createBlockState' which is called in super's <init>, so it is useless
     }
 
     private void setup() {
@@ -63,6 +63,7 @@ public abstract class BlockRailcraftSubtyped<V extends Enum<V> & IVariantEnum> e
 
     @Override
     public final IProperty<V> getVariantProperty() {
+        setup();//'setup' before 'createBlockState'
         return variantProperty;
     }
 


### PR DESCRIPTION
Crash Report:
````
Description: There was a severe problem during mod loading that has caused the game to fail

net.minecraftforge.fml.common.LoaderExceptionModCrash: Caught exception from Railcraft (railcraft)
Caused by: java.lang.NullPointerException
	at net.minecraft.block.state.BlockStateContainer.validateProperty(BlockStateContainer.java:103)
	at net.minecraft.block.state.BlockStateContainer.<init>(BlockStateContainer.java:77)
	at net.minecraft.block.state.BlockStateContainer.<init>(BlockStateContainer.java:62)
	at mods.railcraft.common.blocks.BlockRailcraftSubtyped.createBlockState(BlockRailcraftSubtyped.java:133)
	at net.minecraft.block.Block.<init>(Block.java:290)
	at mods.railcraft.common.blocks.BlockRailcraft.<init>(BlockRailcraft.java:34)
	at mods.railcraft.common.blocks.BlockRailcraftSubtyped.<init>(BlockRailcraftSubtyped.java:50)
	at mods.railcraft.common.blocks.BlockRailcraftSubtyped.<init>(BlockRailcraftSubtyped.java:46)
````

Reproducibility:
Certainly 100%