### PR TITLE
Updated color palette to conform with 1.12

### DIFF
--- a/src/main/java/mods/railcraft/common/plugins/color/EnumColor.java
+++ b/src/main/java/mods/railcraft/common/plugins/color/EnumColor.java
@@ -35,22 +35,22 @@ import java.util.*;
  */
 public enum EnumColor implements IVariantEnum, IRailcraftRecipeIngredient {
 
-    WHITE(0xFFFFFF, "dyeWhite", "white"),
-    ORANGE(0xFF6A00, "dyeOrange", "orange"),
-    MAGENTA(0xFF64FF, "dyeMagenta", "magenta"),
-    LIGHT_BLUE(0x7F9AD1, "dyeLightBlue", "light_blue", "lightBlue"),
-    YELLOW(0xFFC700, "dyeYellow", "yellow"),
-    LIME(0x3FAA36, "dyeLime", "lime"),
-    PINK(0xE585A0, "dyePink", "pink"),
-    GRAY(0x444444, "dyeGray", "gray"),
-    SILVER(0x888888, "dyeLightGray", "light_gray", "silver", "lightGray"),
-    CYAN(0x36809E, "dyeCyan", "cyan"),
-    PURPLE(0x843FBF, "dyePurple", "purple"),
-    BLUE(0x3441A2, "dyeBlue", "blue"),
-    BROWN(0x5C3A24, "dyeBrown", "brown"),
-    GREEN(0x394C1E, "dyeGreen", "green"),
-    RED(0xA33835, "dyeRed", "red"),
-    BLACK(0x2D2D2D, "dyeBlack", "black"),;
+    WHITE(0xF9FFFE, "dyeWhite", "white"),
+    ORANGE(0xF9801D, "dyeOrange", "orange"),
+    MAGENTA(0xC74EBD, "dyeMagenta", "magenta"),
+    LIGHT_BLUE(0x3AB3DA, "dyeLightBlue", "light_blue", "lightBlue"),
+    YELLOW(0xFED83D, "dyeYellow", "yellow"),
+    LIME(0x80C71F, "dyeLime", "lime"),
+    PINK(0xF38BAA, "dyePink", "pink"),
+    GRAY(0x474F52, "dyeGray", "gray"),
+    SILVER(0x9D9D97, "dyeLightGray", "light_gray", "silver", "lightGray"),
+    CYAN(0x169C9C, "dyeCyan", "cyan"),
+    PURPLE(0x8932B8, "dyePurple", "purple"),
+    BLUE(0x3C44AA, "dyeBlue", "blue"),
+    BROWN(0x835432, "dyeBrown", "brown"),
+    GREEN(0x5E7C16, "dyeGreen", "green"),
+    RED(0xB02E26, "dyeRed", "red"),
+    BLACK(0x1D1D21, "dyeBlack", "black"),;
     public static final EnumColor[] VALUES = values();
     public static final EnumColor[] VALUES_INVERTED = values();
     public static final String DEFAULT_COLOR_TAG = "color";


### PR DESCRIPTION
1.12 added a new color palette (see  **[HERE](https://c-5uwzmx78pmca09x24l9c3x781t2ex78ig1sx2ektwclnzwvbx2evmb.g00.gamepedia.com/g00/3_c-5uqvmkzinb.oiumx78mlqi.kwu_/c-5UWZMXPMCA09x24pbbx78ax3ax2fx2fl9c3x781t2ex78ig1s.ktwclnzwvb.vmbx2fuqvmkzinb_oiumx78mlqix2fkx2fk8x2fJivvmzaJmnwzmIvlInbmz.x78vox3fdmzaqwvx3dl2l6036i667ik8n1054jnk6011578181_$/$/$/$/$?i10c.ua=1&i10c.dv=14)** for comparison). This commit changes the palette to conform to the new palette.

Preview with Iron Tank Blocks, with 1.12 wool for comparison
![2018-06-20_03 21 51](https://user-images.githubusercontent.com/1779662/41643752-185228b6-743a-11e8-811d-fd1e7c702b47.png)
