### PR TITLE
fixed blast furnace gui title

### DIFF
--- a/src/main/java/mods/railcraft/client/gui/GuiBlastFurnace.java
+++ b/src/main/java/mods/railcraft/client/gui/GuiBlastFurnace.java
@@ -21,7 +21,7 @@ public class GuiBlastFurnace extends TileGui {
 
     public GuiBlastFurnace(InventoryPlayer par1InventoryPlayer, TileBlastFurnace tile) {
         super(tile, new ContainerBlastFurnace(par1InventoryPlayer, tile), RailcraftConstants.GUI_TEXTURE_FOLDER + "gui_blast_furnace.png",
-                LocalizationPlugin.translateFast("gui.railcraft.coke.oven"));
+                LocalizationPlugin.translateFast("gui.railcraft.blast.furnace"));
         this.tile = tile;
     }
 


### PR DESCRIPTION
![2018-09-12_17 45 44](https://user-images.githubusercontent.com/13639408/45436793-da241880-b6b3-11e8-87bb-5edf8f17cea6.png)

Really small error in the gui code, just changed the title. Was easier to fix by myself than to make an issue