### PR TITLE
Fixed Ic2 classic compat.

### DIFF
--- a/src/main/java/mods/railcraft/common/plugins/misc/Mod.java
+++ b/src/main/java/mods/railcraft/common/plugins/misc/Mod.java
@@ -23,7 +23,7 @@ public enum Mod {
     THAUMCRAFT("thaumcraft"),
     FORESTRY("forestry"),
     IC2("ic2"),
-    IC2_CLASSIC("IC2-Classic-Spmod");
+    IC2_CLASSIC("ic2-classic-spmod");
     //TODO fix modid
 
     public final String modId;


### PR DESCRIPTION
Lang files don't work however, because in the lang files mfsu is lowercase but in the unlocalized name mfsu is uppercase. Either the lang files need to be changed or the unlocalized name needs to be changed. It would probably be easier to change the unlocalized name.