### PR TITLE
Somehow fix compile for guys who want to build directly

### DIFF
--- a/src/main/java/mods/railcraft/common/plugins/forge/CreativePlugin.java
+++ b/src/main/java/mods/railcraft/common/plugins/forge/CreativePlugin.java
@@ -10,7 +10,6 @@
 package mods.railcraft.common.plugins.forge;
 
 import mods.railcraft.common.blocks.RailcraftBlocks;
-import mods.railcraft.common.blocks.charge.BatteryVariant;
 import mods.railcraft.common.items.RailcraftItems;
 import mods.railcraft.common.plugins.color.EnumColor;
 import mods.railcraft.common.util.inventory.InvTools;


### PR DESCRIPTION
**The Issue**
 - Build fails because of a line of redundant import.
 
**The Proposal**
 - Remove that useless import.

**Possible Side Effects**
 - None.
 
**Alternatives**
 - Let CJ fix it in code; (has been a few commits without realizing this issue)
