### PR TITLE
Steam turbine super.update safety

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/multi/TileSteamTurbine.java
+++ b/src/main/java/mods/railcraft/common/blocks/multi/TileSteamTurbine.java
@@ -152,10 +152,9 @@ public final class TileSteamTurbine extends TileMultiBlockCharge implements IMul
 
     @Override
     public void update() {
-        super.update();
-
         if (Game.isHost(world)) {
             if (isValidMaster()) {
+                super.update();
                 addToNet();
                 boolean addedEnergy = false;
                 if (energy < IC2_OUTPUT) {


### PR DESCRIPTION

**The Issue**
Game crashes when a turbine is built, due to it calling TileMultiBlockCharge's update while on the client side
 
**The Proposal**
Move the call 2 lines down into Host-only
 
**Possible Side Effects**
Client-side additions to TileMultiBlockCharge may not be reflected
 
**Alternatives**
Do the host check in TileMultiBlockCharge; more instructions but could be needed in the future?
