### PR TITLE
Add Host check to TileMultiBlockCharge

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/multi/TileMultiBlockCharge.java
+++ b/src/main/java/mods/railcraft/common/blocks/multi/TileMultiBlockCharge.java
@@ -12,6 +12,7 @@ package mods.railcraft.common.blocks.multi;
 
 import mods.railcraft.api.charge.Charge;
 import mods.railcraft.api.charge.IBatteryBlock;
+import mods.railcraft.common.util.misc.Game;
 
 import java.util.List;
 import java.util.Optional;
@@ -37,11 +38,13 @@ public abstract class TileMultiBlockCharge extends TileMultiBlock {
     @Override
     public void update() {
         super.update();
-        if (clock % 16 == 0) {
-            int newComparatorOutput = Charge.distribution.network(world).access(pos).getComparatorOutput();
-            if (prevComparatorOutput != newComparatorOutput)
-                world.updateComparatorOutputLevel(pos, getBlockType());
-            prevComparatorOutput = newComparatorOutput;
+        if (Game.isHost(world)) {
+            if (clock % 16 == 0) {
+                int newComparatorOutput = Charge.distribution.network(world).access(pos).getComparatorOutput();
+                if (prevComparatorOutput != newComparatorOutput)
+                    world.updateComparatorOutputLevel(pos, getBlockType());
+                prevComparatorOutput = newComparatorOutput;
+            }
         }
     }
 

--- a/src/main/java/mods/railcraft/common/blocks/multi/TileMultiBlockCharge.java
+++ b/src/main/java/mods/railcraft/common/blocks/multi/TileMultiBlockCharge.java
@@ -38,13 +38,11 @@ public abstract class TileMultiBlockCharge extends TileMultiBlock {
     @Override
     public void update() {
         super.update();
-        if (Game.isHost(world)) {
-            if (clock % 16 == 0) {
-                int newComparatorOutput = Charge.distribution.network(world).access(pos).getComparatorOutput();
-                if (prevComparatorOutput != newComparatorOutput)
-                    world.updateComparatorOutputLevel(pos, getBlockType());
-                prevComparatorOutput = newComparatorOutput;
-            }
+        if (Game.isHost(world) && clock % 16 == 0) {
+            int newComparatorOutput = Charge.distribution.network(world).access(pos).getComparatorOutput();
+            if (prevComparatorOutput != newComparatorOutput)
+                world.updateComparatorOutputLevel(pos, getBlockType());
+            prevComparatorOutput = newComparatorOutput;
         }
     }
 


### PR DESCRIPTION
**The Issue**
Steam turbine crashes the game due to energy code running on the client
 
**The Proposal**
Add host check to TileMultiBlockCharge's update
 
**Possible Side Effects**
Comparator output will not be immediately updated on the client?
 
**Alternatives**

