### PR TITLE
Fix tank valve states and multiblock rendering when valid

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/BlockEntityDelegate.java
+++ b/src/main/java/mods/railcraft/common/blocks/BlockEntityDelegate.java
@@ -61,7 +61,7 @@ public abstract class BlockEntityDelegate<T extends TileRailcraft & ISmartTile> 
 
     @Override
     public boolean onBlockActivated(World worldIn, BlockPos pos, IBlockState state, EntityPlayer playerIn, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
-        if (hand == EnumHand.OFF_HAND)
+        if (hand == EnumHand.OFF_HAND)  //TODO remove this
             return false;
         return WorldPlugin.getTileEntity(worldIn, pos, ISmartTile.class).map(t -> t.blockActivated(playerIn, hand, side, hitX, hitY, hitZ)).orElse(false);
     }

--- a/src/main/java/mods/railcraft/common/blocks/ISmartTile.java
+++ b/src/main/java/mods/railcraft/common/blocks/ISmartTile.java
@@ -60,8 +60,7 @@ public interface ISmartTile extends ITile {
         EnumGui gui = getGui();
 
         if (gui != null) {
-            BlockPos pos = tile().getPos();
-            GuiHandler.openGui(gui, player, tile().getWorld(), pos.getX(), pos.getY(), pos.getZ());
+            GuiHandler.openGui(gui, player, tile().getWorld(), tile().getPos());
             return true;
         }
         return false;

--- a/src/main/java/mods/railcraft/common/blocks/multi/BlockTankIronValve.java
+++ b/src/main/java/mods/railcraft/common/blocks/multi/BlockTankIronValve.java
@@ -15,30 +15,22 @@ import mods.railcraft.common.items.Metal;
 import mods.railcraft.common.items.RailcraftItems;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
-import net.minecraft.block.properties.PropertyBool;
+import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.Tuple;
-
-import java.util.ArrayList;
-import java.util.EnumMap;
-import java.util.List;
 
 @BlockMetaTile(TileTankIronValve.class)
 public class BlockTankIronValve extends BlockTankIron<TileTankIronValve> {
 
-    public static final EnumMap<EnumFacing, PropertyBool> TOUCHES = new EnumMap<>(EnumFacing.class);
-
-    static {
-        for (EnumFacing face : EnumFacing.VALUES) {
-            TOUCHES.put(face, PropertyBool.create(face.getName2()));
-        }
-    }
+    public static final IProperty<OptionalAxis> OPTIONAL_AXIS = PropertyEnum.create("axis", OptionalAxis.class);
 
     public BlockTankIronValve() {
         super(Material.IRON);
         setHarvestLevel("pickaxe", 1);
+        setDefaultState(getDefaultState().withProperty(OPTIONAL_AXIS, OptionalAxis.NONE));
     }
 
     @Override
@@ -54,16 +46,42 @@ public class BlockTankIronValve extends BlockTankIron<TileTankIronValve> {
 
     @Override
     protected BlockStateContainer createBlockState() {
-        List<IProperty> props = new ArrayList<>();
-        props.add(getVariantProperty());
-        for (EnumFacing face : EnumFacing.VALUES) {
-            props.add(TOUCHES.get(face));
-        }
-        return new BlockStateContainer(this, props.toArray(new IProperty[7]));
+        return new BlockStateContainer(this, OPTIONAL_AXIS);
     }
 
     @Override
     public Tuple<Integer, Integer> getTextureDimensions() {
         return new Tuple<>(2, 1);
+    }
+
+    public enum OptionalAxis implements IStringSerializable {
+        NONE,
+        X,
+        Y,
+        Z;
+
+        final String name;
+
+        OptionalAxis() {
+            this.name = name().toLowerCase();
+        }
+
+        public static OptionalAxis from(EnumFacing.Axis axis) {
+            switch (axis) {
+                case X:
+                    return OptionalAxis.X;
+                case Y:
+                    return OptionalAxis.Y;
+                case Z:
+                    return OptionalAxis.Z;
+                default:
+                    return OptionalAxis.NONE;
+            }
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
     }
 }

--- a/src/main/java/mods/railcraft/common/blocks/multi/BlockTankSteelValve.java
+++ b/src/main/java/mods/railcraft/common/blocks/multi/BlockTankSteelValve.java
@@ -14,14 +14,11 @@ import mods.railcraft.common.blocks.BlockMetaTile;
 import mods.railcraft.common.items.Metal;
 import mods.railcraft.common.items.RailcraftItems;
 import net.minecraft.block.material.Material;
-import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.init.Blocks;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.util.Tuple;
 
-import java.util.ArrayList;
-import java.util.List;
+import static mods.railcraft.common.blocks.multi.BlockTankIronValve.OPTIONAL_AXIS;
 
 @BlockMetaTile(TileTankSteelValve.class)
 public class BlockTankSteelValve extends BlockTankMetal<TileTankSteelValve> {
@@ -29,6 +26,7 @@ public class BlockTankSteelValve extends BlockTankMetal<TileTankSteelValve> {
     public BlockTankSteelValve() {
         super(Material.IRON);
         setHarvestLevel("pickaxe", 1);
+        setDefaultState(getDefaultState().withProperty(OPTIONAL_AXIS, BlockTankIronValve.OptionalAxis.NONE));
     }
 
     @Override
@@ -44,12 +42,7 @@ public class BlockTankSteelValve extends BlockTankMetal<TileTankSteelValve> {
 
     @Override
     protected BlockStateContainer createBlockState() {
-        List<IProperty> props = new ArrayList<>();
-        props.add(getVariantProperty());
-        for (EnumFacing face : EnumFacing.VALUES) {
-            props.add(BlockTankIronValve.TOUCHES.get(face));
-        }
-        return new BlockStateContainer(this, props.toArray(new IProperty[7]));
+        return new BlockStateContainer(this, OPTIONAL_AXIS);
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/blocks/multi/IMultiBlockTile.java
+++ b/src/main/java/mods/railcraft/common/blocks/multi/IMultiBlockTile.java
@@ -27,10 +27,9 @@ public interface IMultiBlockTile extends IOwnable, ITile {
      */
     boolean isValidMaster();
 
-    @Nullable
-    TileMultiBlock getMasterBlock();
+    @Nullable TileMultiBlock getMasterBlock();
 
-    MultiBlockPattern getCurrentPattern();
+    @Nullable MultiBlockPattern getCurrentPattern();
 
     MultiBlockState getState();
 

--- a/src/main/java/mods/railcraft/common/blocks/multi/MultiBlockPattern.java
+++ b/src/main/java/mods/railcraft/common/blocks/multi/MultiBlockPattern.java
@@ -245,6 +245,7 @@ public final class MultiBlockPattern {
     public enum State {
 
         VALID(TileMultiBlock.MultiBlockState.VALID, "railcraft.multiblock.state.valid"),
+        // TODO map to untested?
         ENTITY_IN_WAY(TileMultiBlock.MultiBlockState.INVALID, "railcraft.multiblock.state.invalid.entity"),
         PATTERN_DOES_NOT_MATCH(TileMultiBlock.MultiBlockState.INVALID, "railcraft.multiblock.state.invalid.pattern"),
         NOT_LOADED(TileMultiBlock.MultiBlockState.UNKNOWN, "railcraft.multiblock.state.unknown.unloaded");

--- a/src/main/java/mods/railcraft/common/blocks/multi/TileBoilerTank.java
+++ b/src/main/java/mods/railcraft/common/blocks/multi/TileBoilerTank.java
@@ -20,6 +20,8 @@ import net.minecraft.util.math.BlockPos;
 import java.io.IOException;
 import java.util.function.Predicate;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author CovertJaguar <http://www.railcraft.info>
  */
@@ -41,11 +43,12 @@ public abstract class TileBoilerTank extends TileBoiler {
         if (marker == 'O')
             return state;
         BlockPos patternPos = getPatternPosition();
+        MultiBlockPattern pattern = requireNonNull(getCurrentPattern());
         state = state
-                .withProperty(BlockBoilerTank.NORTH, getCurrentPattern().getPatternMarker(patternPos.offset(EnumFacing.NORTH)) == marker)
-                .withProperty(BlockBoilerTank.SOUTH, getCurrentPattern().getPatternMarker(patternPos.offset(EnumFacing.SOUTH)) == marker)
-                .withProperty(BlockBoilerTank.EAST, getCurrentPattern().getPatternMarker(patternPos.offset(EnumFacing.EAST)) == marker)
-                .withProperty(BlockBoilerTank.WEST, getCurrentPattern().getPatternMarker(patternPos.offset(EnumFacing.WEST)) == marker);
+                .withProperty(BlockBoilerTank.NORTH, pattern.getPatternMarker(patternPos.offset(EnumFacing.NORTH)) == marker)
+                .withProperty(BlockBoilerTank.SOUTH, pattern.getPatternMarker(patternPos.offset(EnumFacing.SOUTH)) == marker)
+                .withProperty(BlockBoilerTank.EAST, pattern.getPatternMarker(patternPos.offset(EnumFacing.EAST)) == marker)
+                .withProperty(BlockBoilerTank.WEST, pattern.getPatternMarker(patternPos.offset(EnumFacing.WEST)) == marker);
         return state;
     }
 

--- a/src/main/java/mods/railcraft/common/blocks/multi/TileSteamTurbine.java
+++ b/src/main/java/mods/railcraft/common/blocks/multi/TileSteamTurbine.java
@@ -53,6 +53,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author CovertJaguar <http://www.railcraft.info>
  */
@@ -454,7 +456,7 @@ public final class TileSteamTurbine extends TileMultiBlockCharge implements IMul
         if (!isStructureValid()) {
             return base;
         }
-        MultiBlockPattern currentPattern = getCurrentPattern();
+        MultiBlockPattern currentPattern = requireNonNull(getCurrentPattern());
         Axis axis = currentPattern.getAttachedData(Axis.X);
         base = base.withProperty(BlockSteamTurbine.WINDOW, getPatternMarker() == 'W')
                 .withProperty(BlockSteamTurbine.LONG_AXIS, axis);

--- a/src/main/java/mods/railcraft/common/blocks/multi/TileTankIronValve.java
+++ b/src/main/java/mods/railcraft/common/blocks/multi/TileTankIronValve.java
@@ -16,7 +16,6 @@ import mods.railcraft.common.fluids.tanks.FakeTank;
 import mods.railcraft.common.fluids.tanks.StandardTank;
 import mods.railcraft.common.util.misc.Game;
 import mods.railcraft.common.util.misc.Predicates;
-import net.minecraft.block.properties.PropertyBool;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -28,7 +27,7 @@ import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Map;
+import static java.util.Objects.requireNonNull;
 
 /**
  * @author CovertJaguar <http://www.railcraft.info>
@@ -144,9 +143,12 @@ public class TileTankIronValve extends TileTankBase implements IFluidHandler, IT
         if (!isStructureValid())
             return base.getBlock().getDefaultState();
         BlockPos pos = getPatternPosition();
-        MultiBlockPattern pattern = getPattern();
-        for (Map.Entry<EnumFacing, PropertyBool> entry : BlockTankIronValve.TOUCHES.entrySet()) {
-            base = base.withProperty(entry.getValue(), !isMapPositionOtherBlock(pattern.getPatternMarkerChecked(pos.offset(entry.getKey()))));
+        MultiBlockPattern pattern = requireNonNull(getPattern());
+        for (EnumFacing facing : EnumFacing.VALUES) {
+            if (isMapPositionOtherBlock(pattern.getPatternMarkerChecked(pos.offset(facing)))) {
+                base = base.withProperty(BlockTankIronValve.OPTIONAL_AXIS, BlockTankIronValve.OptionalAxis.from(facing.getAxis()));
+                break;
+            }
         }
         return base;
     }

--- a/src/main/resources/assets/railcraft/blockstates/tank_iron_valve.json
+++ b/src/main/resources/assets/railcraft/blockstates/tank_iron_valve.json
@@ -15,76 +15,38 @@
         "transform": "forge:default-block"
       }
     ],
-    "north": {
-      "true": {
-        "textures": {
-          "north": "railcraft:blocks/tank_iron_wall_1"
-        }
+    "axis": {
+      "none": {
+        "north": "railcraft:blocks/tank_iron_valve_1",
+        "south": "railcraft:blocks/tank_iron_valve_1",
+        "west": "railcraft:blocks/tank_iron_valve_1",
+        "east": "railcraft:blocks/tank_iron_valve_1",
+        "up": "railcraft:blocks/tank_iron_valve_0",
+        "down": "railcraft:blocks/tank_iron_valve_0"
       },
-      "false": {
-        "textures": {
-          "north": "railcraft:blocks/tank_iron_valve_1"
-        }
-      }
-    },
-    "south": {
-      "true": {
-        "textures": {
-          "south": "railcraft:blocks/tank_iron_wall_1"
-        }
+      "x": {
+        "north": "railcraft:blocks/tank_iron_wall_1",
+        "south": "railcraft:blocks/tank_iron_wall_1",
+        "west": "railcraft:blocks/tank_iron_valve_1",
+        "east": "railcraft:blocks/tank_iron_valve_1",
+        "up": "railcraft:blocks/tank_iron_wall_0",
+        "down": "railcraft:blocks/tank_iron_wall_0"
       },
-      "false": {
-        "textures": {
-          "south": "railcraft:blocks/tank_iron_valve_1"
-        }
-      }
-    },
-    "west": {
-      "true": {
-        "textures": {
-          "west": "railcraft:blocks/tank_iron_wall_1"
-        }
+      "y": {
+        "north": "railcraft:blocks/tank_iron_wall_1",
+        "south": "railcraft:blocks/tank_iron_wall_1",
+        "west": "railcraft:blocks/tank_iron_wall_1",
+        "east": "railcraft:blocks/tank_iron_wall_1",
+        "up": "railcraft:blocks/tank_iron_valve_0",
+        "down": "railcraft:blocks/tank_iron_valve_0"
       },
-      "false": {
-        "textures": {
-          "west": "railcraft:blocks/tank_iron_valve_1"
-        }
-      }
-    },
-    "east": {
-      "true": {
-        "textures": {
-          "east": "railcraft:blocks/tank_iron_wall_1"
-        }
-      },
-      "false": {
-        "textures": {
-          "east": "railcraft:blocks/tank_iron_valve_1"
-        }
-      }
-    },
-    "up": {
-      "true": {
-        "textures": {
-          "up": "railcraft:blocks/tank_iron_wall_0"
-        }
-      },
-      "false": {
-        "textures": {
-          "up": "railcraft:blocks/tank_iron_valve_0"
-        }
-      }
-    },
-    "down": {
-      "true": {
-        "textures": {
-          "down": "railcraft:blocks/tank_iron_wall_0"
-        }
-      },
-      "false": {
-        "textures": {
-          "down": "railcraft:blocks/tank_iron_valve_0"
-        }
+      "z": {
+        "north": "railcraft:blocks/tank_iron_valve_1",
+        "south": "railcraft:blocks/tank_iron_valve_1",
+        "west": "railcraft:blocks/tank_iron_wall_1",
+        "east": "railcraft:blocks/tank_iron_wall_1",
+        "up": "railcraft:blocks/tank_iron_wall_0",
+        "down": "railcraft:blocks/tank_iron_wall_0"
       }
     }
   }


### PR DESCRIPTION
**The Issue**
 - Multiblocks are considered valid on the server (tested via mag glass) but don't show up as valid and do not show up gui.
 - The tank valves have 2^6, or 64, states while it just needs 4.
 
**The Proposal**
 - Changed tank valves to use only 4 states
 - Added assertions and make sure the states are updated properly with multiblocks.
 
**Possible Side Effects**
 - Might hurt your ongoing progress on moving the multiblock patterns into logics.
 
**Alternatives**
 - Leaving the tank valves with 64 states is too costly, so I changed it
 - Prompted a todo message so that if some block need off hand functionality we can add it.
