### PR TITLE
Allow getting the texture to draw over the analog widget needle from elsewhere.

### DIFF
--- a/src/main/java/mods/railcraft/common/gui/containers/ContainerRockCrusher.java
+++ b/src/main/java/mods/railcraft/common/gui/containers/ContainerRockCrusher.java
@@ -31,7 +31,7 @@ public class ContainerRockCrusher extends RailcraftContainer {
     public ContainerRockCrusher(InventoryPlayer inventoryplayer, TileRockCrusher crusher) {
         super(crusher);
         this.tile = crusher;
-        addWidget(new AnalogWidget(new ChargeNetworkIndicator(tile.getWorld(), tile.getPos()), 74, 59, 28, 14));
+        addWidget(new AnalogWidget(new ChargeNetworkIndicator(tile.getWorld(), tile.getPos()), 74, 59, 28, 14, 99, 65));
 
         for (int i = 0; i < 3; i++) {
             for (int k = 0; k < 3; k++) {

--- a/src/main/java/mods/railcraft/common/gui/containers/ContainerRollingMachinePowered.java
+++ b/src/main/java/mods/railcraft/common/gui/containers/ContainerRollingMachinePowered.java
@@ -18,6 +18,6 @@ public class ContainerRollingMachinePowered extends ContainerRollingMachine {
 
     public ContainerRollingMachinePowered(final InventoryPlayer inventoryplayer, final TileRollingMachinePowered tile) {
         super(inventoryplayer, tile, 93, 17);
-        addWidget(new AnalogWidget(new ChargeNetworkIndicator(tile.getWorld(), tile.getPos()), 87, 54, 28, 14));
+        addWidget(new AnalogWidget(new ChargeNetworkIndicator(tile.getWorld(), tile.getPos()), 87, 54, 28, 14, 99, 65));
     }
 }

--- a/src/main/java/mods/railcraft/common/gui/containers/ContainerTurbine.java
+++ b/src/main/java/mods/railcraft/common/gui/containers/ContainerTurbine.java
@@ -30,7 +30,7 @@ public class ContainerTurbine extends RailcraftContainer {
         super(tile.getInventory());
         this.tile = tile;
 
-        addWidget(new AnalogWidget(new ChargeNetworkIndicator(tile.getWorld(), tile.getPos()), 110, 38, 28, 14));
+        addWidget(new AnalogWidget(new ChargeNetworkIndicator(tile.getWorld(), tile.getPos()), 110, 38, 28, 14, 99, 65));
 
         addSlot(new SlotTurbine(tile.getInventory(), 0, 60, 24));
         for (int i = 0; i < 3; i++) {

--- a/src/main/java/mods/railcraft/common/gui/widgets/AnalogWidget.java
+++ b/src/main/java/mods/railcraft/common/gui/widgets/AnalogWidget.java
@@ -23,12 +23,30 @@ import org.lwjgl.opengl.GL11;
  */
 public class AnalogWidget extends MeterWidget {
 
-    public AnalogWidget(IIndicatorController controller, int x, int y, int w, int h) {
+    protected final int ox, oy, ou, ov;
+
+    public AnalogWidget(IIndicatorController controller, int x, int y, int w, int h, int ox, int oy, int ou, int ov) {
         super(controller, x, y, 0, 0, w, h);
+        this.ox = ox;
+        this.oy = oy;
+        this.ou = ou;
+        this.ov = ov;
     }
 
-    public AnalogWidget(IIndicatorController controller, int x, int y, int w, int h, boolean vertical) {
+    public AnalogWidget(IIndicatorController controller, int x, int y, int w, int h, int ox, int oy) {
+        this(controller, x, y, w, h, ox, oy, ox, oy);
+    }
+
+    public AnalogWidget(IIndicatorController controller, int x, int y, int w, int h, int ox, int oy, int ou, int ov, boolean vertical) {
         super(controller, x, y, 0, 0, w, h, vertical);
+        this.ox = ox;
+        this.oy = oy;
+        this.ou = ou;
+        this.ov = ov;
+    }
+
+    public AnalogWidget(IIndicatorController controller, int x, int y, int w, int h, int ox, int oy, boolean vertical) {
+        this(controller, x, y, w, h, ox, oy, ox, oy, vertical);
     }
 
     @Override
@@ -86,6 +104,6 @@ public class AnalogWidget extends MeterWidget {
         // resetting
         OpenGL.glEnable(GL11.GL_TEXTURE_2D);
 
-        gui.drawTexturedModalRect(guiX + 99, guiY + 65, 99, 65, 4, 3);
+        gui.drawTexturedModalRect(guiX + ox, guiY + oy, ou, ov, 4, 3);
     }
 }


### PR DESCRIPTION
Addons that want to use the fancy analog widget for their own machines might have the widget elsewhere on the GUI texture, meaning the texture to draw over the needle might be elsewhere. This allows addon devs to use the analog widget without having to copy the class only to change a single line.