### PR TITLE
Added not ic2 classic check to slag dust macerator recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ README.txt
 .idea/modules.xml
 .idea/gradle.xml
 .idea/compiler.xml
+.idea
 *.iml
 run/
 private/

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ README.txt
 .idea/modules.xml
 .idea/gradle.xml
 .idea/compiler.xml
-.idea
 *.iml
 run/
 private/

--- a/src/main/java/mods/railcraft/common/items/ItemDust.java
+++ b/src/main/java/mods/railcraft/common/items/ItemDust.java
@@ -59,8 +59,10 @@ public class ItemDust extends ItemRailcraftSubtyped {
             if (RailcraftConfig.getRecipeConfig("ic2.macerator.ender")) {
                 IC2Plugin.addMaceratorRecipe(new ItemStack(Items.ENDER_PEARL), getStack(EnumDust.ENDER));
             }
-            if (RailcraftConfig.getRecipeConfig("ic2.macerator.slag")) {
-                IC2Plugin.addMaceratorRecipe(ModItems.SLAG.getStack(), getStack(EnumDust.SLAG));
+            if (!Mod.IC2_CLASSIC.isLoaded()){
+                if (RailcraftConfig.getRecipeConfig("ic2.macerator.slag")) {
+                    IC2Plugin.addMaceratorRecipe(ModItems.SLAG.getStack(), getStack(EnumDust.SLAG));
+                }
             }
         }
     }


### PR DESCRIPTION

**The Issue**
If Ic2 Classic is loaded a recipe for slag dust is added that uses the no use item from ic2 classic.
 
**The Proposal**
I added a check for ic2 classic to that recipe so it doesn't get added if ic2 classic is loaded.
Granted, the recipe was not accessible, but it still was annoying me.
 
**Possible Side Effects**
none that I'm aware of.
 
**Alternatives**
I did consider just removing the recipe in my mod but I couldn't seem to get it to work and this seemed not only easier but would also not require my mod to be loaded.

Also by the way I added the complete .idea folder to the .gitignore file as it was only ignoring certain files which meant files in my local repo wanted to be added.