### PR TITLE
Some resource for debugging and running in dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ README.txt
 .idea/tasks.xml
 .idea/modules.xml
 .idea/gradle.xml
+.idea/runConfigurations/
 .idea/compiler.xml
 *.iml
 run/

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+import groovy.xml.MarkupBuilder
 import net.minecraftforge.gradle.tasks.SignJar
 
 buildscript {
@@ -54,11 +55,6 @@ println 'Environment: ' + project.environment
 println '*************************************************************'
 println ''
 
-// Change the 4G in -Xmx4G to your desired max RAM and 4G in -Xms4G to your desired initial RAM
-def optimizedVmArgs = ['-XX:+UseG1GC', '-Xmx4G', '-Xms4G', '-XX:+UnlockExperimentalVMOptions', '-XX:G1NewSizePercent=20', '-XX:G1ReservePercent=20', '-XX:MaxGCPauseMillis=50', '-XX:G1HeapRegionSize=32M']
-def assertionVmArgs = ['-ea:mods.railcraft...', '-ea:net.minecraft...', '-ea:net.minecraftforge...']
-def combinedVmArgs = [assertionVmArgs, optimizedVmArgs].flatten()
-
 minecraft {
     version = project.version_minecraft + "-" + project.version_forge
     runDir = "run"
@@ -67,7 +63,17 @@ minecraft {
 
     replace '@VERSION@', project.version
     makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
+}
 
+def actualRunDir = project.file(minecraft.runDir)
+// Change the 4G in -Xmx4G to your desired max RAM and 4G in -Xms4G to your desired initial RAM
+def optimizedVmArgs = ['-XX:+UseG1GC', '-Xmx4G', '-Xms4G', '-XX:+UnlockExperimentalVMOptions', '-XX:G1NewSizePercent=20', '-XX:G1ReservePercent=20', '-XX:MaxGCPauseMillis=50', '-XX:G1HeapRegionSize=32M']
+def assertionVmArgs = ['-ea:mods.railcraft...', '-ea:net.minecraft...', '-ea:net.minecraftforge...']
+def log4jVmArgs = ['-Dlog4j.configurationFile=' + new File(actualRunDir, 'log4j2.xml').toString()]
+def combinedVmArgs = [assertionVmArgs, optimizedVmArgs, log4jVmArgs].flatten()
+def extraEnvs = new LinkedHashMap() //['LOG4J_CONFIGURATION_FILE': "log4j2.xml"]
+
+minecraft {
     clientJvmArgs = combinedVmArgs
     serverJvmArgs = combinedVmArgs
 }
@@ -149,44 +155,71 @@ processResources {
     }
 }
 
-//tasks.genIntellijRuns.doLast {
-//    def runConfigurationsDir = new File(".idea/runConfigurations")
-//    runConfigurationsDir.mkdirs()
-//
-//    tasks.withType(JavaExec).each { task ->
-//        def taskName = task.name
-//        def mainClass = task.main
-//        def props = task.systemProperties.collect { k, v -> "-D$k=$v" }.join(' ')
-//        def args = task.args.join(" ")
-//
-//        def writer = new FileWriter(new File(runConfigurationsDir, "${taskName}.xml"))
-//        def xml = new MarkupBuilder(writer)
-//
-//        xml.component(name: "ProjectRunConfigurationManager") {
-//            configuration(default: 'false', name: taskName, type: "Application", factoryName: "Application", singleton: "true") {
-//                option(name: 'MAIN_CLASS_NAME', value: mainClass)
-//                option(name: 'VM_PARAMETERS', value: props)
-//                option(name: 'PROGRAM_PARAMETERS', value: args)
-//                option(name: 'WORKING_DIRECTORY', value: 'file://$PROJECT_DIR$')
-//                module(name: 'module-name', value: 'railcraft.main')
-//            }
-//        }
-//    }
-//}
-
 runClient {
     // in git bash, do (replace stuff in the <>) ./gradlew runClient -PmcUsername=<your minecraft login email> -PmcPassword=<your minecraft password>
     if (project.hasProperty('mcUsername') && project.hasProperty('mcPassword')) {
         args "--username=${project.mcUsername}"
         args "--password=${project.mcPassword}"
     }
-//    environment("LOG4J_CONFIGURATION_FILE", "../extras/log4j2.xml")
-    outputs.upToDateWhen { false }
 }
 
 runServer {
-//    environment("LOG4J_CONFIGURATION_FILE", "../extras/log4j2.xml")
+    doFirst {
+        new File(workingDir, "eula.txt").text = "eula=true"
+    }
+    args "nogui" // no server gui, we have console
+}
+
+task copyLog4jConfig(type: Copy) {
+    from('extras') {
+        include 'log4j2.xml'
+    }
+    into actualRunDir
+}
+
+tasks.withType(JavaExec) {
+    dependsOn copyLog4jConfig
+    environment extraEnvs
     outputs.upToDateWhen { false }
+    workingDir actualRunDir
+}
+
+genIntellijRuns {
+    dependsOn copyLog4jConfig
+    doLast {
+        def runConfigurationsDir = new File(".idea/runConfigurations")
+        runConfigurationsDir.mkdirs()
+
+        tasks.withType(JavaExec).each { task ->
+            def taskName = task.name
+            def mainClass = task.main
+            def props = combinedVmArgs.join(' ') // task.jvmArgs.join(' ') has too much trash
+            def args = task.args.join(' ')
+
+            def writer = new FileWriter(new File(runConfigurationsDir, "${taskName}.xml"))
+            def xml = new MarkupBuilder(writer)
+
+            xml.component(name: "ProjectRunConfigurationManager") {
+                configuration(default: 'false', name: taskName, type: "Application", factoryName: "Application", singleton: "true") {
+                    option(name: 'MAIN_CLASS_NAME', value: mainClass)
+                    option(name: 'VM_PARAMETERS', value: props)
+                    option(name: 'PROGRAM_PARAMETERS', value: args)
+                    option(name: 'WORKING_DIRECTORY', value: task.workingDir)
+                    envs() {
+                        extraEnvs.entrySet().each { envVar ->
+                            env(name: envVar.key, value: envVar.value)
+                        }
+                    }
+                    module(name: 'railcraft_main')
+                    // copy log4j config before running
+                    method(v: '2') {
+                        option(name: 'Make', enabled: 'true')
+                        option(name: 'Gradle.BeforeRunTask', enabled: 'true', tasks: 'copyLog4jConfig', externalProjectPath: '$PROJECT_DIR$')
+                    }
+                }
+            }
+        }
+    }
 }
 
 compileJava {

--- a/extras/log4j2.xml
+++ b/extras/log4j2.xml
@@ -2,7 +2,12 @@
 <Configuration status="INFO">
     <Appenders>
         <Console name="SysOut" target="SYSTEM_OUT">
-            <LegacyXMLLayout />
+            <!--LegacyXMLLayout / note: this is for the stupid mojang launcher-->
+            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg%n" />
+            <Policies>
+                <TimeBasedTriggeringPolicy />
+                <OnStartupTriggeringPolicy />
+            </Policies>
         </Console>
         <RollingRandomAccessFile name="File" fileName="logs/latest.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
             <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg%n" />
@@ -11,9 +16,21 @@
                 <OnStartupTriggeringPolicy />
             </Policies>
         </RollingRandomAccessFile>
+        <RollingRandomAccessFile name="RailcraftFile" fileName="logs/railcraft.log" filePattern="logs/%d{yyyy-MM-dd}-%i.railcraft.log.gz">
+            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg%n" />
+            <Policies>
+                <TimeBasedTriggeringPolicy />
+                <OnStartupTriggeringPolicy />
+            </Policies>
+        </RollingRandomAccessFile>
     </Appenders>
     <Loggers>
-        <Root level="trace">
+        <Logger name="railcraft" level="trace" additivity="false">
+            <AppenderRef ref="SysOut"/>
+            <AppenderRef ref="File"/>
+            <AppenderRef ref="RailcraftFile"/>
+        </Logger>
+        <Root level="debug">
             <filters>
                 <MarkerFilter marker="NETWORK_PACKETS" onMatch="DENY" onMismatch="NEUTRAL" />
             </filters>

--- a/src/main/java/mods/railcraft/common/blocks/machine/worldspike/TileWorldspike.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/worldspike/TileWorldspike.java
@@ -66,7 +66,7 @@ public class TileWorldspike extends TileMachineItem implements IWorldspike, ISid
     private static final int[] SLOTS_NO_ACCESS = {};
     private BlockPos pointPos = BlockPos.ORIGIN;
     private int prevX, prevY, prevZ;
-    private Set<ChunkPos> chunks;
+    private @Nullable Set<ChunkPos> chunks;
     private long fuel;
     private int fuelCycle;
     private boolean hasTicket;
@@ -117,8 +117,7 @@ public class TileWorldspike extends TileMachineItem implements IWorldspike, ISid
         return super.blockActivated(player, hand, side, hitX, hitY, hitZ);
     }
 
-    @Nullable
-    public static WorldCoordinate getTarget(EntityPlayer player) {
+    public static @Nullable WorldCoordinate getTarget(EntityPlayer player) {
         return pointPairingMap.get(player);
     }
 
@@ -335,8 +334,7 @@ public class TileWorldspike extends TileMachineItem implements IWorldspike, ISid
         return !powered && (hasFuel() || !needsFuel());
     }
 
-    @Nullable
-    protected Ticket getTicketFromForge() {
+    protected @Nullable Ticket getTicketFromForge() {
         return ForgeChunkManager.requestTicket(Railcraft.getMod(), world, Type.NORMAL);
     }
 
@@ -358,8 +356,7 @@ public class TileWorldspike extends TileMachineItem implements IWorldspike, ISid
         return getTicket() != null;
     }
 
-    @Nullable
-    public Ticket getTicket() {
+    public @Nullable Ticket getTicket() {
         return tickets.get(getUUID());
     }
 
@@ -473,7 +470,8 @@ public class TileWorldspike extends TileMachineItem implements IWorldspike, ISid
 
         powered = data.getBoolean("powered");
 
-        pointPos = NBTPlugin.readBlockPos(data, "point");
+        BlockPos pos = NBTPlugin.readBlockPos(data, "point");
+        pointPos = pos == null ? BlockPos.ORIGIN : pos;
 
         prevX = data.getInteger("prevX");
         prevY = data.getInteger("prevY");

--- a/src/main/java/mods/railcraft/common/util/collections/BlockItemParser.java
+++ b/src/main/java/mods/railcraft/common/util/collections/BlockItemParser.java
@@ -20,10 +20,7 @@ import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 
 /**
@@ -95,7 +92,7 @@ public class BlockItemParser {
 
     public static <T, V> Map<T, V> parseDictionary(String[] list, String logMessage, Function<String, T> keyParser, Function<String, V> valueParser) {
         try {
-            Map<T, V> map = new HashMap<T, V>();
+            Map<T, V> map = new HashMap<>();
             for (String line : list) {
                 line = line.replaceAll("[{} ]", "");
                 if (StringUtils.isEmpty(line))
@@ -108,7 +105,7 @@ public class BlockItemParser {
         } catch (IllegalArgumentException ex) {
             throw ex;
         } catch (RuntimeException ex) {
-            throw new IllegalArgumentException("Invalid map while parsing config = " + list);
+            throw new IllegalArgumentException("Invalid map while parsing config = " + Arrays.toString(list));
         }
     }
 

--- a/src/main/java/mods/railcraft/common/util/collections/ItemKey.java
+++ b/src/main/java/mods/railcraft/common/util/collections/ItemKey.java
@@ -12,22 +12,23 @@ package mods.railcraft.common.util.collections;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
+import net.minecraftforge.registries.IRegistryDelegate;
 
 /**
  * @author CovertJaguar <http://www.railcraft.info>
  */
 public final class ItemKey {
 
-    public final Item item;
+    public final IRegistryDelegate<Item> item;
     public final int metadata;
 
     public ItemKey(Item item) {
-        this.item = item;
+        this.item = item.delegate;
         this.metadata = -1;
     }
 
     public ItemKey(Item item, int metadata) {
-        this.item = item;
+        this.item = item.delegate;
         this.metadata = metadata;
     }
 
@@ -36,7 +37,7 @@ public final class ItemKey {
     }
 
     public ItemStack asStack() {
-        return new ItemStack(item, 1, metadata == -1 ? OreDictionary.WILDCARD_VALUE : metadata);
+        return new ItemStack(item.get(), 1, metadata == -1 ? OreDictionary.WILDCARD_VALUE : metadata);
     }
 
     @Override


### PR DESCRIPTION
**The Issue**
 - Forge gradle's intellij idea run task is usually glitchy. It frequently fails to copy the args and does not set up the module to run properly.
 
**The Proposal**
 - Generate more idea run tasks beyond the ones provided by fg
 - The new tasks include:
  - VM args suggested by cpw
  - assertion vm args
  - log4j config to enable debug logging in vanilla
  - set the module to `railcraft_main` so that you don't need to set again
  - if the `password.properties` exist, the generated run configuration for client will automatically log you in to mojang services
  - automatically generate eula file for server launch and specify `nogui` (not showing the swing gui for dedicated server)
 - also fixed a few poor code usages in the project found during browsing
 
**Possible Side Effects**
 - The original forgegradle run tasks are still preserved as `Minecraft Client/Server`, while the new ones are called the same as the gradle task name `runClient`/`runServer`. If people dislike new ones, they can still use the old tasks.
 
**Alternatives**
 - Tweaking the existing task may cause side effects, so I chose to add new tasks.
