### PR TITLE
Update readme to prevent discord spam

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In the words of **CovertJaguar**:
 * The Blog, Forums, and main download page: http://www.railcraft.info
 * The Wiki: http://railcraft.info/wiki
 * IRC: #railcraft on Esper.net - [WebChat](http://webchat.esper.net/?nick=RailcraftGithub...&channels=railcraft&prompt=1)
-* Discord: [Invite](https://discord.gg/Wr9zxmP) - Linked with #railcraft on IRC
+* Discord: [Invite](https://discord.gg/VyaUt2r) - Linked with #railcraft on IRC
 * Patreon Page: http://www.patreon.com/CovertJaguar
 
 <a href="http://www.patreon.com/CovertJaguar"> ![Patreon](http://www.railcraft.info/wp-content/uploads/2014/05/Patreon.png)</a>


### PR DESCRIPTION
**The Issue**
 - Spam bots on DiscordApp
 - The old link to general channel was removed.
 
**The Proposal**
 - Change link to VyaUt2r
 
**Possible Side Effects**
 - A few other links on the blog (@CovertJaguar ), wiki, and in mod guild (@liach ) will be updated separately. The links in the discord server is fine.
 
**Alternatives**
 - Leaving it as it is will cause confusions.