### PR TITLE
Remove iterable from IInventoryComposite

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/logic/InventoryLogic.java
+++ b/src/main/java/mods/railcraft/common/blocks/logic/InventoryLogic.java
@@ -45,8 +45,8 @@ public abstract class InventoryLogic extends Logic implements IInventoryImplemen
     }
 
     @Override
-    public Iterator<InventoryAdaptor> iterator() {
-        return composite.iterator();
+    public Iterator<InventoryAdaptor> adaptors() {
+        return composite.adaptors();
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/util/inventory/InvTools.java
+++ b/src/main/java/mods/railcraft/common/util/inventory/InvTools.java
@@ -266,7 +266,7 @@ public abstract class InvTools {
 
     static boolean tryRemove(IInventoryComposite comp, int amount, Predicate<ItemStack> filter, InvOp op) {
         int amountNeeded = amount;
-        for (InventoryAdaptor inv : comp) {
+        for (InventoryAdaptor inv : comp.iterable()) {
             List<ItemStack> stacks = inv.extractItems(amountNeeded, filter, op);
             amountNeeded -= stacks.stream().mapToInt(InvTools::sizeOf).sum();
             if (amountNeeded <= 0)


### PR DESCRIPTION
This resolves the interface conflict with sponge inventory api 7 and is not too costly.

Signed-off-by: liach <liach@users.noreply.github.com>

**The Issue**
 - #1607
 
**The Proposal**
 - Remove iterable from the `IInventoryComposite` interface.

**Why**
 - The iterable is not very widely used in Railcraft code (as seen in the changes here)
 - Sponge API is already finalized for Minecraft 1.12, making change on their side hard
 - Even if I use compat mod to make things run, the iterable contracts from two sides are different and will cause more subtle bugs. (Sponge contract: iterator iterates through rows; Railcraft: through sub inventory adaptors, which is actually the singleton inventory adaptor)
 
**Possible Side Effects**
 - This change should be clean and have no other side effects (code compiles)
 
**Alternatives**
 - Keeping as it is is not helpful given now the overwhelming majority of minecraft plugin-mod hybrid servers are based on SpongeForge. Though there is ftbutil, etc., they are more limited than sponge in general.