### PR TITLE
Fixes #1664

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/tracks/outfitted/ItemTrackKit.java
+++ b/src/main/java/mods/railcraft/common/blocks/tracks/outfitted/ItemTrackKit.java
@@ -42,6 +42,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.oredict.OreDictionary;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
@@ -73,6 +74,8 @@ public class ItemTrackKit extends ItemRailcraft {
 
     @Override
     public int getMetadata(ItemStack stack) {
+        if (super.getMetadata(stack) == OreDictionary.WILDCARD_VALUE)
+            return OreDictionary.WILDCARD_VALUE; // Keep this for the sake of forestry backpack item identification
         return TrackRegistry.TRACK_KIT.getId(TrackRegistry.TRACK_KIT.get(stack));
     }
 

--- a/src/main/java/mods/railcraft/common/carts/EntityLocomotive.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityLocomotive.java
@@ -643,6 +643,7 @@ public abstract class EntityLocomotive extends CartBaseContainer implements IDir
         data.writeEnum(clientMode);
         data.writeEnum(clientSpeed);
         data.writeInt(lockController.getCurrentState());
+        data.writeBoolean(isReverse());
     }
 
     @Override
@@ -652,6 +653,7 @@ public abstract class EntityLocomotive extends CartBaseContainer implements IDir
         int lock = data.readInt();
         if (PlayerPlugin.isOwnerOrOp(getOwner(), sender.getGameProfile()))
             lockController.setCurrentState(lock);
+        setReverse(data.readBoolean());
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/modules/ModuleForestry.java
+++ b/src/main/java/mods/railcraft/common/modules/ModuleForestry.java
@@ -56,7 +56,7 @@ public class ModuleForestry extends RailcraftModulePayload {
 
             @Override
             @Optional.Method(modid = ForestryPlugin.FORESTRY_ID)
-            public void postInit() {
+            public void init() {
                 if (RailcraftItems.FILTER_BEE_GENOME.isEnabled()) {
                     ForestryPlugin.instance().registerBeeFilterRecipe();
                 }

--- a/src/main/java/mods/railcraft/common/plugins/forestry/BaseBackpack.java
+++ b/src/main/java/mods/railcraft/common/plugins/forestry/BaseBackpack.java
@@ -20,7 +20,6 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.text.translation.I18n;
 import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.oredict.OreDictionary;
 import org.jetbrains.annotations.Nullable;
@@ -56,6 +55,8 @@ public abstract class BaseBackpack implements IBackpackDefinition {
     }
 
     public void add(IRailcraftObjectContainer objectContainer) {
+        if (!objectContainer.isLoaded())
+            return;
         add(objectContainer.getWildcard());
     }
 
@@ -80,7 +81,7 @@ public abstract class BaseBackpack implements IBackpackDefinition {
     @Override
     public String getName(ItemStack backpack) {
         Item item = backpack.getItem();
-        String name = ("" + I18n.translateToLocal(LocalizationPlugin.convertTag(item.getTranslationKey()) + ".name")).trim();
+        String name = LocalizationPlugin.translateFast(LocalizationPlugin.convertTag(item.getTranslationKey()) + ".name").trim();
 
         if (backpack.getTagCompound() != null && backpack.getTagCompound().hasKey("display", 10)) {
             NBTTagCompound nbt = backpack.getTagCompound().getCompoundTag("display");

--- a/src/main/java/mods/railcraft/common/plugins/forestry/TrackmanBackpack.java
+++ b/src/main/java/mods/railcraft/common/plugins/forestry/TrackmanBackpack.java
@@ -11,6 +11,8 @@ package mods.railcraft.common.plugins.forestry;
 
 import mods.railcraft.api.items.IMinecartItem;
 import mods.railcraft.api.items.IToolCrowbar;
+import mods.railcraft.api.items.ITrackItem;
+import mods.railcraft.api.tracks.IItemTrack;
 import mods.railcraft.common.blocks.RailcraftBlocks;
 import mods.railcraft.common.blocks.tracks.TrackTools;
 import mods.railcraft.common.items.RailcraftItems;
@@ -19,6 +21,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemMinecart;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.Optional;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
 
 /**
  * @author CovertJaguar <http://www.railcraft.info>
@@ -39,17 +42,13 @@ public class TrackmanBackpack extends BaseBackpack {
     }
 
     public void setup() {
-
-        for (ResourceLocation id : Block.REGISTRY.getKeys()) {
-            Block block = Block.REGISTRY.getObject(id);
-            if (block == null) continue;
+        for (Block block : ForgeRegistries.BLOCKS.getValuesCollection()) {
             if (TrackTools.isRailBlock(block))
                 add(block);
         }
 
-        for (ResourceLocation id : Item.REGISTRY.getKeys()) {
-            Item item = Item.REGISTRY.getObject(id);
-            if (item instanceof ItemMinecart || item instanceof IMinecartItem)
+        for (Item item : ForgeRegistries.ITEMS.getValuesCollection()) {
+            if (item instanceof ItemMinecart || item instanceof IMinecartItem || item instanceof ITrackItem || item instanceof IItemTrack)
                 add(item);
         }
 


### PR DESCRIPTION
**The Issue**
 - #1664 
 - #1506
 - Inventory composite crashes on iron golems
 
**The Proposal**
 - Change the throw to an empty iterator since some entities don't have inventories
 - Cleans up some forestry related code
 - Syncs reversal status on gui return to help fix #1506 
 - Change track kit meta handling to take oredict wildcard as a special case for forestry backpacks
 
**Possible Side Effects**
 - The oredict wildcard special case might affect other usages which I am not sure.
 - Dunno why you decided to throw originally for the inventory composite.
 
**Alternatives**
 - I could have returned true meta, but I did not because I don't know if that hurts other usages of track kit
