### PR TITLE
Move imc handling out of mod class

### DIFF
--- a/src/main/java/mods/railcraft/common/carts/ItemTunnelBore.java
+++ b/src/main/java/mods/railcraft/common/carts/ItemTunnelBore.java
@@ -9,15 +9,21 @@
  -----------------------------------------------------------------------------*/
 package mods.railcraft.common.carts;
 
+import com.google.common.collect.Iterables;
+import com.google.common.primitives.Ints;
 import com.mojang.authlib.GameProfile;
 import mods.railcraft.api.carts.CartToolsAPI;
 import mods.railcraft.common.blocks.tracks.TrackShapeHelper;
 import mods.railcraft.common.blocks.tracks.TrackTools;
+import mods.railcraft.common.core.IInterModMessageHandler;
+import mods.railcraft.common.core.InterModMessageRegistry;
 import mods.railcraft.common.plugins.forge.CraftingPlugin;
 import mods.railcraft.common.plugins.forge.WorldPlugin;
 import mods.railcraft.common.util.entity.EntitySearcher;
+import mods.railcraft.common.util.misc.BallastRegistry;
 import mods.railcraft.common.util.misc.Game;
 import mods.railcraft.common.util.misc.MiscTools;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockRailBase;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.item.EntityMinecart;
@@ -30,6 +36,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import org.apache.logging.log4j.Level;
 import org.jetbrains.annotations.Nullable;
 
 import static mods.railcraft.common.util.inventory.InvTools.dec;
@@ -39,6 +46,27 @@ public class ItemTunnelBore extends ItemCart {
     public ItemTunnelBore(IRailcraftCartContainer cart) {
         super(cart);
         maxStackSize = 1;
+    }
+
+    @Override
+    public void initializeDefinition() {
+        super.initializeDefinition();
+        InterModMessageRegistry.getInstance().register("ballast", mess -> {
+            String[] tokens = Iterables.toArray(IInterModMessageHandler.SPLITTER.split(mess.getStringValue()), String.class);
+            if (tokens.length != 2) {
+                Game.log().msg(Level.WARN, String.format("Mod %s attempted to register a ballast, but failed: %s", mess.getSender(), mess.getStringValue()));
+                return;
+            }
+            String blockName = tokens[0];
+            Integer metadata = Ints.tryParse(tokens[1]);
+            Block block;
+            if (blockName == null || metadata == null || (block = Block.getBlockFromName(blockName)) == null) {
+                Game.log().msg(Level.WARN, String.format("Mod %s attempted to register a ballast, but failed: %s", mess.getSender(), mess.getStringValue()));
+                return;
+            }
+            BallastRegistry.registerBallast(block, metadata);
+            Game.log().msg(Level.DEBUG, String.format("Mod %s registered %s as a valid ballast", mess.getSender(), mess.getStringValue()));
+        });
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/core/IInterModMessageHandler.java
+++ b/src/main/java/mods/railcraft/common/core/IInterModMessageHandler.java
@@ -1,0 +1,34 @@
+/*------------------------------------------------------------------------------
+ Copyright (c) CovertJaguar, 2011-2019
+ http://railcraft.info
+
+ This code is the property of CovertJaguar
+ and may only be used with explicit written
+ permission unless otherwise specified on the
+ license page at http://railcraft.info/wiki/info:license.
+ -----------------------------------------------------------------------------*/
+
+package mods.railcraft.common.core;
+
+import com.google.common.base.Splitter;
+import net.minecraftforge.fml.common.event.FMLInterModComms;
+
+/**
+ * Handles inter-mod communication (IMC) messages.
+ */
+@FunctionalInterface
+public interface IInterModMessageHandler {
+
+    /**
+     * A splitter to split string messages.
+     */
+    Splitter SPLITTER = Splitter.on("@").trimResults();
+
+    /**
+     * Interpret an IMC message.
+     *
+     * @param message the IMC message to interpret
+     * @throws RuntimeException when a fatal problem occurs
+     */
+    void handle(FMLInterModComms.IMCMessage message);
+}

--- a/src/main/java/mods/railcraft/common/core/InterModMessageRegistry.java
+++ b/src/main/java/mods/railcraft/common/core/InterModMessageRegistry.java
@@ -1,0 +1,55 @@
+/*------------------------------------------------------------------------------
+ Copyright (c) CovertJaguar, 2011-2019
+ http://railcraft.info
+
+ This code is the property of CovertJaguar
+ and may only be used with explicit written
+ permission unless otherwise specified on the
+ license page at http://railcraft.info/wiki/info:license.
+ -----------------------------------------------------------------------------*/
+
+package mods.railcraft.common.core;
+
+import mods.railcraft.common.util.misc.Game;
+import net.minecraftforge.fml.common.event.FMLInterModComms;
+import org.apache.logging.log4j.Level;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class InterModMessageRegistry {
+
+    // convert to something contained in mod object/module manager at some point
+    private static final InterModMessageRegistry INSTANCE = new InterModMessageRegistry();
+    private final Map<String, IInterModMessageHandler> handlers = new HashMap<>();
+    private boolean called; // may be called multiple times
+
+    public static InterModMessageRegistry getInstance() {
+        return INSTANCE;
+    }
+
+    public void register(String key, IInterModMessageHandler handler) {
+        if (called) {
+            Game.log().msg(Level.ERROR, "IMC event has passed when a handler is registered for key {0}", key);
+            if (Game.DEVELOPMENT_VERSION)
+                throw new IllegalStateException("IMC registration is too late!");
+        }
+        IInterModMessageHandler old = handlers.put(key, handler);
+        if (old != null) {
+            Game.log().msg(Level.INFO, "Overridden previous IMC handler for key {0}", key);
+        }
+    }
+
+    public void handle(FMLInterModComms.IMCMessage message) {
+        called = true;
+        IInterModMessageHandler handler = handlers.get(message.key);
+        if (handler == null) {
+            // Some handlers are not registered when some parts of Railcraft is disabled
+            Game.log().msg(Level.DEBUG, "Mod {0} sent an ignored IMC message with key {1}", message.getSender(), message.key);
+            return;
+        }
+        handler.handle(message);
+    }
+
+    private InterModMessageRegistry() {}
+}


### PR DESCRIPTION
**The Issue**
 - #1696
 - Rock crusher recipe registration via IMC was not ported.
 
**The Proposal**
 - Port the rock crusher recipe IMC registration partially.
 - Move IMC handling code out of railcraft mod class.
 
**Possible Side Effects**
 - The NBT handling request of old rock crusher recipes is ignored.
 - IMC code cannot be maintained together in the future, but can be maintained with the features they related to/modify.
 
**Alternatives**
 - Adding NBT handling support: It would be too much work on ingredients as vanilla ingredients are not nbt aware.
