### PR TITLE
Remove or deprecate y<0 statements for cubic chunks

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/BlockEntityDelegate.java
+++ b/src/main/java/mods/railcraft/common/blocks/BlockEntityDelegate.java
@@ -165,8 +165,8 @@ public abstract class BlockEntityDelegate<T extends TileRailcraft & ISmartTile> 
 
     @Override
     public int getLightValue(IBlockState state, IBlockAccess world, BlockPos pos) {
-        if (pos.getY() < 0)
-            return 0;
+//        if (pos.getY() < 0)
+//            return 0; // cubic chunks
         return TileManager.forTile(this::getTileClass, state, world, pos)
                 .retrieve(ITileLit.class, ITileLit::getLightValue).orElse(0);
     }

--- a/src/main/java/mods/railcraft/common/gui/GuiHandler.java
+++ b/src/main/java/mods/railcraft/common/gui/GuiHandler.java
@@ -42,7 +42,7 @@ public class GuiHandler implements IGuiHandler {
     public static void openGui(EnumGui gui, EntityPlayer player, World world, Entity entity) {
         if (Game.isHost(world)) {
             if (gui.hasContainer()) {
-                player.openGui(Railcraft.getMod(), gui.ordinal(), world, entity.getEntityId(), -1, 0);
+                player.openGui(Railcraft.getMod(), gui.ordinal(), world, entity.getEntityId(), Integer.MIN_VALUE, 0);
             }
         } else if (!gui.hasContainer()) {
             FMLClientHandler.instance().displayGuiScreen(player, FactoryGui.build(gui, player.inventory, entity, world, entity.getEntityId(), -1, 0));
@@ -51,7 +51,7 @@ public class GuiHandler implements IGuiHandler {
 
     @Override
     public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-        if (y < 0) {
+        if (y == Integer.MIN_VALUE) {
             Entity entity = world.getEntityByID(x);
             if (entity == null) {
                 Game.log().msg(Level.WARN, "[Server] Entity not found when opening GUI: {0}", x);
@@ -65,7 +65,7 @@ public class GuiHandler implements IGuiHandler {
 
     @Override
     public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-        if (y < 0) {
+        if (y == Integer.MIN_VALUE) {
             Entity entity = world.getEntityByID(x);
             if (entity == null) {
                 Game.log().msg(Level.WARN, "[Client] Entity not found when opening GUI: {0}", x);

--- a/src/main/java/mods/railcraft/common/plugins/forge/WorldPlugin.java
+++ b/src/main/java/mods/railcraft/common/plugins/forge/WorldPlugin.java
@@ -48,10 +48,10 @@ public class WorldPlugin {
 
     public static @Nullable TileEntity getBlockTile(IBlockAccess world, BlockPos pos) {
         // see flowerpot source code
-        if (pos.getY() < 0) {
-            // dunno if this will be triggered by tiles at y=0
-            Game.log().msg(Level.INFO, "Attempted to access tile entity in an invalid position");
-        }
+//        if (pos.getY() < 0) { // cubic chunks
+//            // dunno if this will be triggered by tiles at y=0
+//            Game.log().msg(Level.INFO, "Attempted to access tile entity in an invalid position");
+//        }
         return world instanceof ChunkCache ? ((ChunkCache) world).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : world.getTileEntity(pos);
     }
 

--- a/src/main/java/mods/railcraft/common/util/misc/AABBFactory.java
+++ b/src/main/java/mods/railcraft/common/util/misc/AABBFactory.java
@@ -125,8 +125,8 @@ public class AABBFactory {
     }
 
     public AABBFactory clampToWorld() {
-        if (minY < 0)
-            minY = 0;
+//        if (minY < 0)
+//            minY = 0; // cubic chunks
         return this;
     }
 


### PR DESCRIPTION
**The Issue**
 - #1689
 - Removed y<0 checks
 
**The Proposal**
 - Remove y<0 checks
 - Use integer min value to indicate entity gui instead
 
**Possible Side Effects**
 - Might break some safety guarantees; not sure
 
**Alternatives**
 - Some people use cubic chunks, so adding its compatibility is a nice choice. The change is not too large, either.

@Barteks2x please look at this as well.
