### PR TITLE
Fixes #1623

### DIFF
--- a/src/main/java/mods/railcraft/common/plugins/forge/OreDictPlugin.java
+++ b/src/main/java/mods/railcraft/common/plugins/forge/OreDictPlugin.java
@@ -76,7 +76,7 @@ public final class OreDictPlugin {
     }
 
     public static boolean oreExists(String name) {
-        return OreDictionary.doesOreNameExist(name);
+        return !OreDictionary.getOres(name, false).isEmpty();
     }
 
     public static Set<IBlockState> getOreBlockStates() {


### PR DESCRIPTION
**The Issue**
 - #1623 
 - When an empty oredict entry exist, we assume it has items and withdraw our recipes.
 
**The Proposal**
 - Change the check to test against the existence of ores.
 - When empty oredicts for bronze/invar dust is added, bronze/invar recipe breaks as well, so this method.
 
**Possible Side Effects**
 - This method is only used in ingot recipe registration of 3 alloys and in `isOreType` in oredict plugin. Does not produce exceptional behavior as I can see.
 
**Alternatives**
 - Removing the oredict check for brass can only help fixing brass, but cannot work for bronze or invar when invtweak is present and no other invar/bronze mod is present.