### PR TITLE
Simplify void chest particles

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/single/BlockChestVoid.java
+++ b/src/main/java/mods/railcraft/common/blocks/single/BlockChestVoid.java
@@ -11,18 +11,17 @@
 package mods.railcraft.common.blocks.single;
 
 import mods.railcraft.client.render.tesr.TESRChest;
-import mods.railcraft.client.render.tools.RenderTools;
 import mods.railcraft.common.blocks.BlockMeta;
 import mods.railcraft.common.items.ItemDust;
 import mods.railcraft.common.items.RailcraftItems;
 import mods.railcraft.common.plugins.forge.CraftingPlugin;
-import mods.railcraft.common.plugins.forge.WorldPlugin;
+import mods.railcraft.common.util.misc.MathTools;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.relauncher.Side;
@@ -43,40 +42,9 @@ public class BlockChestVoid extends BlockChestRailcraft<TileChestVoid> {
     @Override
     public void randomDisplayTick(IBlockState stateIn, World worldIn, BlockPos pos, Random rand) {
         super.randomDisplayTick(stateIn, worldIn, pos, rand);
-        BlockPos start = new BlockPos(pos.getX() - 10 + rand.nextInt(20), pos.getY(), pos.getZ() - 10 + rand.nextInt(20));
-        spawnVoidFaceParticles(worldIn, start);
-    }
-
-    @SideOnly(Side.CLIENT)
-    private void spawnVoidFaceParticles(World worldIn, BlockPos pos) {
-        Random random = worldIn.rand;
-        double pixel = RenderTools.PIXEL;
-
-        IBlockState state = WorldPlugin.getBlockState(worldIn, pos);
-
-        for (EnumFacing facing : EnumFacing.VALUES) {
-            if (!state.shouldSideBeRendered(worldIn, pos, facing)) continue;
-
-            double px = pos.getX();
-            double py = pos.getY();
-            double pz = pos.getZ();
-
-            if (facing.getAxis() == EnumFacing.Axis.X)
-                px += pixel * facing.getXOffset() + (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE ? 1.0 : 0.0);
-            else
-                px += random.nextFloat();
-
-            if (facing.getAxis() == EnumFacing.Axis.Y)
-                py += pixel * facing.getYOffset() + (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE ? 1.0 : 0.0);
-            else
-                py += random.nextFloat();
-
-            if (facing.getAxis() == EnumFacing.Axis.Z)
-                pz += pixel * facing.getZOffset() + (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE ? 1.0 : 0.0);
-            else
-                pz += random.nextFloat();
-
-            worldIn.spawnParticle(EnumParticleTypes.SUSPENDED_DEPTH, px, py, pz, 0.0D, 0.0D, 0.0D);
+        for (int i = 0; i < 3; i++) {
+            Vec3d start = new Vec3d(pos.getX() + MathTools.signedFloat(rand), pos.getY(), pos.getZ() + (MathTools.signedFloat(rand)));
+            worldIn.spawnParticle(EnumParticleTypes.SUSPENDED_DEPTH, start.x, start.y, start.z, MathTools.signedFloat(rand), MathTools.signedFloat(rand), MathTools.signedFloat(rand));
         }
     }
 

--- a/src/main/java/mods/railcraft/common/util/misc/MathTools.java
+++ b/src/main/java/mods/railcraft/common/util/misc/MathTools.java
@@ -14,6 +14,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3i;
 
 import java.util.Collection;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -69,5 +70,26 @@ public final class MathTools {
 
     public static float nextFloat() {
         return RAND.nextFloat();
+    }
+
+    public static float signedFloat() {
+        return signedFloat(RAND);
+    }
+
+    public static float signedFloat(Random random) {
+        return unit(random) * random.nextFloat();
+    }
+
+    public static int unit() {
+        return unit(RAND);
+    }
+
+    /**
+     * Returns {@code 1} or {@code -1} by random.
+     *
+     * @param random the seed
+     */
+    public static int unit(Random random) {
+        return random.nextInt(2) * 2 - 1;
     }
 }


### PR DESCRIPTION
**The Issue**
 - #1690
 - Void particles have a range that is too wide.
 
**The Proposal**
 - Decrease the range and make the particles like that of the ender chest more.
 
**Possible Side Effects**
 - Particles may be less noticeable.
 - Added a few random helper methods as well.
 
**Alternatives**
 - I did not add a config option because most people are able to tolerate vanilla particles, etc. and particles can be turned off in settings as well.
