### PR TITLE
Fix track layer stock pulling

### DIFF
--- a/src/main/java/mods/railcraft/common/carts/CartBaseMaintenancePattern.java
+++ b/src/main/java/mods/railcraft/common/carts/CartBaseMaintenancePattern.java
@@ -61,14 +61,14 @@ public abstract class CartBaseMaintenancePattern extends CartBaseMaintenance imp
         if (!stackStock.isEmpty() && !InvTools.isItemEqual(stackReplace, stackStock)) {
             CartToolsAPI.transferHelper().offerOrDropItem(this, stackStock);
             setInventorySlotContents(slotStock, InvTools.emptyStack());
-            stackStock = null;
+            stackStock = ItemStack.EMPTY;
         }
 
         if (stackReplace.isEmpty())
             return;
 
-        if (stackStock == null)
-            setInventorySlotContents(slotStock, CartToolsAPI.transferHelper().pullStack(this, StackFilters.of(stackReplace)));
+        if (!InvTools.isStackFull(stackStock) && stackStock.getCount() < getInventoryStackLimit())
+            setInventorySlotContents(slotStock, InvTools.copy(stackReplace, stackStock.getCount() + CartToolsAPI.transferHelper().pullStack(this, StackFilters.of(stackReplace)).getCount()));
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/util/inventory/InvTools.java
+++ b/src/main/java/mods/railcraft/common/util/inventory/InvTools.java
@@ -507,4 +507,16 @@ public abstract class InvTools {
     public static double calculateFullness(IInventoryManipulator manipulator) {
         return manipulator.streamSlots().mapToDouble(slot -> slot.getStack().getCount() / (double) slot.getMaxStackSize()).average().orElse(0.0);
     }
+
+    /**
+     * Checks if a stack can have more items filled in.
+     *
+     * <p>Callers: Be warned that you need to check slot stack limit as well!
+     *
+     * @param stack the stack to check
+     * @return whether the stack needs filling
+     */
+    public static boolean isStackFull(ItemStack stack) {
+        return stack.isEmpty() || stack.getCount() == stack.getMaxStackSize();
+    }
 }

--- a/src/main/java/mods/railcraft/common/util/inventory/InvTools.java
+++ b/src/main/java/mods/railcraft/common/util/inventory/InvTools.java
@@ -517,6 +517,6 @@ public abstract class InvTools {
      * @return whether the stack needs filling
      */
     public static boolean isStackFull(ItemStack stack) {
-        return stack.isEmpty() || stack.getCount() == stack.getMaxStackSize();
+        return !stack.isEmpty() && stack.getCount() == stack.getMaxStackSize();
     }
 }


### PR DESCRIPTION
**The Issue**
 - Fix track layer stock pulling from chest carts #1716
 
**The Proposal**
 - Always pull; not waiting till the stock is empty. Also fixed null usage for item stacks.
 
**Possible Side Effects**
 - Might affect other maintenance carts as well (heard relayer had a similar bug)
 
**Alternatives**
 - I think this is the most obvious place and most correct place to fix.
