### PR TITLE
Allows to disable spawner cart

### DIFF
--- a/src/main/java/mods/railcraft/common/modules/ModuleCore.java
+++ b/src/main/java/mods/railcraft/common/modules/ModuleCore.java
@@ -237,7 +237,8 @@ public class ModuleCore extends RailcraftModulePayload {
                 replaceVanillaCart(names, RailcraftCarts.FURNACE, Items.FURNACE_MINECART, EntityMinecart.Type.FURNACE, 44);
                 replaceVanillaCart(names, RailcraftCarts.TNT, Items.TNT_MINECART, EntityMinecart.Type.TNT, 45);
                 replaceVanillaCart(names, RailcraftCarts.HOPPER, Items.HOPPER_MINECART, EntityMinecart.Type.HOPPER, 46);
-                replaceVanillaCart(names, RailcraftCarts.SPAWNER, null, EntityMinecart.Type.SPAWNER, 47);
+                if (RailcraftCarts.SPAWNER.isLoaded())
+                    replaceVanillaCart(names, RailcraftCarts.SPAWNER, null, EntityMinecart.Type.SPAWNER, 47);
 
                 float h = TrackConstants.HARDNESS;
                 Blocks.RAIL.setHardness(h).setHarvestLevel("crowbar", 0);


### PR DESCRIPTION
**The Issue**
 - Allows to disable spawner cart substitution, fixes #1717 and first concern in #1724
 
**The Proposal**
 - Adds an enabled check.
 
**Possible Side Effects**
 - I really don't recommend this as it breaks our season integration! (Default spawner carts do not have )
 
**Alternatives**
 - We can refuse disabling, but I'd give users more freedom.
