### PR TITLE
Fix an invalid override that broke fluid recipes

### DIFF
--- a/src/main/java/mods/railcraft/common/util/crafting/ShapedRailcraftRecipe.java
+++ b/src/main/java/mods/railcraft/common/util/crafting/ShapedRailcraftRecipe.java
@@ -89,7 +89,8 @@ public final class ShapedRailcraftRecipe extends ShapedRecipes {
     /**
      * Checks if the region of a crafting inventory is match for the recipe.
      */
-    private boolean checkMatch(InventoryCrafting p_77573_1_, int p_77573_2_, int p_77573_3_, boolean p_77573_4_) {
+    @Override
+    protected boolean checkMatch(InventoryCrafting p_77573_1_, int p_77573_2_, int p_77573_3_, boolean p_77573_4_) {
         requireNonNull(bySlots);
         Arrays.fill(bySlots, null);
         for (int i = 0; i < p_77573_1_.getWidth(); ++i) {

--- a/src/main/resources/META-INF/railcraft_at.cfg
+++ b/src/main/resources/META-INF/railcraft_at.cfg
@@ -12,3 +12,4 @@ protected net.minecraft.entity.item.EntityMinecart field_70500_g # MATRIX
 public net.minecraft.tileentity.TileEntity field_190562_f # REGISTRY
 protected-f net.minecraft.entity.item.EntityMinecartMobSpawner field_98040_a # mobSpawnerLogic
 protected net.minecraft.inventory.InventoryBasic field_70482_c # inventoryContents
+protected net.minecraft.item.crafting.ShapedRecipes func_77573_a(Lnet/minecraft/inventory/InventoryCrafting;IIZ)Z # checkMatch


### PR DESCRIPTION
**The Issue**
 - ![The glitch](https://cdn.discordapp.com/attachments/452113315322396673/546911260772532224/A.gif)
 
**The Proposal**
 - Fix the invalid override of `checkMatch` method.
 
**Possible Side Effects**
 - None that I can see.

**Alternatives**
 - Overriding `matches` brings too many lines of changes, so I did not override that method and used an access transformer entry instead.
