### PR TITLE
Make macerator recipe removals more specific

### DIFF
--- a/src/main/java/mods/railcraft/common/modules/ModuleIC2.java
+++ b/src/main/java/mods/railcraft/common/modules/ModuleIC2.java
@@ -23,6 +23,7 @@ import mods.railcraft.common.plugins.misc.Mod;
 import mods.railcraft.common.util.inventory.InvTools;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 //import mods.railcraft.common.plugins.ic2.crops.*;
@@ -57,10 +58,6 @@ public class ModuleIC2 extends RailcraftModulePayload {
             @Override
             public void init() {
             //    Crops.instance.registerCrop(new CropCreosote()); ##Save this for when a proper crafting recipe is possible
-            }
-
-            @Override
-            public void postInit() {
 //                Block blockDetector = RailcraftBlocks.DETECTOR.block();
 //
 //                if (blockDetector != null) {
@@ -167,16 +164,18 @@ public class ModuleIC2 extends RailcraftModulePayload {
                 }
 
                 if (!RailcraftConfig.getRecipeConfig("ic2.macerator.bones"))
-                    IC2Plugin.removeMaceratorRecipes(new ItemStack(Items.DYE, 1, 15));
+                    IC2Plugin.removeMaceratorRecipes(new ItemStack(Items.BONE), new ItemStack(Items.DYE, 1, 15));
 
                 if (!RailcraftConfig.getRecipeConfig("ic2.macerator.blaze"))
-                    IC2Plugin.removeMaceratorRecipes(new ItemStack(Items.BLAZE_POWDER));
+                    IC2Plugin.removeMaceratorRecipes(new ItemStack(Items.BLAZE_ROD), new ItemStack(Items.BLAZE_POWDER));
 
-                if (!RailcraftConfig.getRecipeConfig("ic2.macerator.cobble"))
-                    IC2Plugin.removeMaceratorRecipes(new ItemStack(Blocks.COBBLESTONE));
+                if (!RailcraftConfig.getRecipeConfig("ic2.macerator.cobble")) {
+                    IC2Plugin.removeMaceratorRecipes(new ItemStack(Blocks.COBBLESTONE), new ItemStack(Blocks.SAND));
+                    IC2Plugin.removeMaceratorRecipes(new ItemStack(Blocks.STONE), new ItemStack(Blocks.COBBLESTONE));
+                }
 
                 if (!RailcraftConfig.getRecipeConfig("ic2.macerator.dirt"))
-                    IC2Plugin.removeMaceratorRecipes(new ItemStack(Blocks.DIRT));
+                    IC2Plugin.removeMaceratorRecipes(recipe -> recipe.getOutput().stream().anyMatch(item -> item.getItem() == Item.getItemFromBlock(Blocks.DIRT)));
             }
         });
     }

--- a/src/main/java/mods/railcraft/common/modules/ModuleResources.java
+++ b/src/main/java/mods/railcraft/common/modules/ModuleResources.java
@@ -144,7 +144,7 @@ public class ModuleResources extends RailcraftModulePayload {
 
                     if (Mod.anyLoaded(Mod.IC2, Mod.IC2_CLASSIC) && RailcraftItems.DUST.isEnabled()) {
                         ItemStack obsidian = new ItemStack(Blocks.OBSIDIAN);
-                        IC2Plugin.removeMaceratorRecipes(recipe -> recipe.getInput().matches(obsidian));
+                        IC2Plugin.removeMaceratorRecipes(recipe -> recipe.getInput().matches(obsidian) && OreDictPlugin.hasOreType("dustObsidian", recipe.getOutput()));
                         if (RailcraftConfig.getRecipeConfig("ic2.macerator.obsidian")) {
                             IC2Plugin.addMaceratorRecipe(new ItemStack(Blocks.OBSIDIAN), stack);
                             IC2Plugin.addMaceratorRecipe(stack, RailcraftItems.DUST.getStack(ItemDust.EnumDust.OBSIDIAN));

--- a/src/main/java/mods/railcraft/common/plugins/forge/OreDictPlugin.java
+++ b/src/main/java/mods/railcraft/common/plugins/forge/OreDictPlugin.java
@@ -38,6 +38,14 @@ public final class OreDictPlugin {
         OreDictionary.registerOre("gateWood", Blocks.SPRUCE_FENCE_GATE);
     }
 
+    public static boolean hasOreType(String oreName, Iterable<ItemStack> stacks) {
+        for (ItemStack stack : stacks) {
+            if (isOreType(oreName, stack))
+                return true;
+        }
+        return false;
+    }
+
     public static boolean isOreType(String oreName, ItemStack stack) {
         if (!oreExists(oreName))
             return false;

--- a/src/main/java/mods/railcraft/common/plugins/ic2/IC2Plugin.java
+++ b/src/main/java/mods/railcraft/common/plugins/ic2/IC2Plugin.java
@@ -161,11 +161,8 @@ public class IC2Plugin {
         removeMaceratorRecipes(recipe -> (isInputBlock(recipe.getInput()) && doesRecipeProduce(recipe.getOutput(), items)));
     }
 
-    /**
-     * Removes either by input or result.
-     */
-    public static void removeMaceratorRecipes(ItemStack item) {
-        removeMaceratorRecipes(recipe -> doesRecipeRequire(recipe.getInput(), item) || doesRecipeProduce(recipe.getOutput(), item));
+    public static void removeMaceratorRecipes(ItemStack input, ItemStack output) {
+        removeMaceratorRecipes(recipe -> doesRecipeRequire(recipe.getInput(), input) || doesRecipeProduce(recipe.getOutput(), output));
     }
 
     public static void removeMaceratorRecipes(Predicate<? super MachineRecipe<? extends IRecipeInput, Collection<ItemStack>>> predicate) {


### PR DESCRIPTION
**The Issue**
 - Make macerator recipe removals more specific. Closes #1719 
 
**The Proposal**
 - Changed the recipe removals to be more specific. See https://wiki.industrial-craft.net/index.php?title=Macerator
 
**Possible Side Effects**
 - Also moved machine recipe removal to init
 
**Alternatives**
None. The default config does not remove these recipes, so nah.
