### PR TITLE
Make sure removed trains are actually removed in file

### DIFF
--- a/src/main/java/mods/railcraft/common/carts/Train.java
+++ b/src/main/java/mods/railcraft/common/carts/Train.java
@@ -83,10 +83,15 @@ public final class Train implements Iterable<EntityMinecart> {
 
     public static Object getTicker() {
         return new Object() {
+
+            int counter = 0;
+
             @SubscribeEvent
             public void tick(TickEvent.WorldTickEvent event) {
                 if (event.side == Side.SERVER && event.phase == TickEvent.Phase.END) {
-                    getManager(event.world).ifPresent(Manager::tick);
+                    counter++;
+                    if (counter % 32 == 0)
+                        getManager(event.world).ifPresent(Manager::tick);
                 }
             }
         };
@@ -494,6 +499,7 @@ public final class Train implements Iterable<EntityMinecart> {
                 if (train.isDead || train.isInvalid()) {
                     train.clear();
                     it.remove();
+                    data.markDirty();
                 }
             }
         }

--- a/src/test/java/tests/TrainSaveAnalyzer.java
+++ b/src/test/java/tests/TrainSaveAnalyzer.java
@@ -1,0 +1,46 @@
+package tests;
+
+import mods.railcraft.common.plugins.forge.NBTPlugin;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.nbt.NBTUtil;
+import net.minecraftforge.common.util.Constants;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class TrainSaveAnalyzer {
+
+    private static final String FILE = "C:\\mc\\one" + "\\railcraft.trains.dat";
+    private static final Logger LOGGER = LogManager.getLogger("train save analyzer");
+
+    public static void main(String... args) throws IOException {
+        File file = new File(FILE);
+        Set<UUID> seen = new HashSet<>();
+        LOGGER.info("Starting");
+        NBTTagCompound root = CompressedStreamTools.readCompressed(new BufferedInputStream(new FileInputStream(file)));
+        NBTTagList list = root.getCompoundTag("data").getTagList("trains", Constants.NBT.TAG_COMPOUND);
+        for (NBTTagCompound tag : NBTPlugin.<NBTTagCompound>asList(list)) {
+            List<UUID> carts = NBTPlugin.getNBTList(tag, "carts", NBTTagCompound.class).stream().map(NBTUtil::getUUIDFromTag).collect(Collectors.toList());
+            for (UUID cart : carts) {
+                if (seen.contains(cart)) {
+                    LOGGER.error("Found duplicate minecart of uuid {}", cart);
+                } else {
+                    seen.add(cart);
+                    LOGGER.trace("Added cart of uuid {}", cart);
+                }
+            }
+        }
+        LOGGER.info("Finished");
+    }
+}

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level] [%logger]: %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
**The Issue**
 - Fixes #1724 
 - Existing servers can delete old `railcraft.trains.dat` file in `data` folder of world directory to relieve this.
 
**The Proposal**
 - Scan through all trains less frequently.
 - Make sure to mark the data as dirty after trains are removed.
 - Adds a utility to see if there is any duplicate cart in railcraft.trains.dat file.
 
**Possible Side Effects**
 - Not much I can see.
 
**Alternatives**
?
