### PR TITLE
Fix/obsidian crushing macerator

### DIFF
--- a/src/main/java/mods/railcraft/common/core/RailcraftConfig.java
+++ b/src/main/java/mods/railcraft/common/core/RailcraftConfig.java
@@ -370,7 +370,7 @@ public class RailcraftConfig {
         loadRecipeProperty("railcraft.cart", "steel", true, "change to '{t}=false' to disable the steel recipe for minecarts");
         loadRecipeProperty("railcraft.cart", "vanilla.furnace", true, "change to '{t}=false' to disable the Furnace Minecart recipe");
         loadRecipeProperty("ic2.macerator", "crushed.obsidian", true, "change to '{t}=false' to disable the IC2 Macerator recipe from Obsidian to Crushed Obsidian");
-        loadRecipeProperty("ic2.macerator", "obsidian", true, "change to '{t}=false' to disable any IC2 Macerator recipe with Obsidian input");
+        loadRecipeProperty("ic2.macerator", "obsidian", true, "change to '{t}=false' to disable any IC2 Macerator recipe with Obsidian input; overridden by the crushed obsidian setting");
         loadRecipeProperty("ic2.macerator", "charcoal", true, "change to '{t}=false' to disable the IC2 Macerator recipe for Charcoal Dust");
         loadRecipeProperty("ic2.macerator", "ores", true, "change to '{t}=false' to disable the IC2 Macerator recipes for Ore Dusts");
         loadRecipeProperty("ic2.macerator", "bones", true, "change to '{t}=false' to disable the IC2 Macerator recipe for Bonemeal");

--- a/src/main/java/mods/railcraft/common/core/RailcraftConfig.java
+++ b/src/main/java/mods/railcraft/common/core/RailcraftConfig.java
@@ -369,12 +369,13 @@ public class RailcraftConfig {
         loadRecipeProperty("railcraft.cart", "bronze", true, "change to '{t}=false' to disable the bronze recipe for minecarts");
         loadRecipeProperty("railcraft.cart", "steel", true, "change to '{t}=false' to disable the steel recipe for minecarts");
         loadRecipeProperty("railcraft.cart", "vanilla.furnace", true, "change to '{t}=false' to disable the Furnace Minecart recipe");
-        loadRecipeProperty("ic2.macerator", "obsidian", true, "change to '{t}=false' to disable the IC2 Macerator recipes for Crushed Obsidian and Obsidian Dust");
+        loadRecipeProperty("ic2.macerator", "crushed.obsidian", true, "change to '{t}=false' to remove the IC2 Macerator recipes from Obsidian to Crushed Obsidian");
+        loadRecipeProperty("ic2.macerator", "obsidian", true, "change to '{t}=false' to remove the IC2 Macerator recipes with Obsidian input");
         loadRecipeProperty("ic2.macerator", "charcoal", true, "change to '{t}=false' to disable the IC2 Macerator recipe for Charcoal Dust");
         loadRecipeProperty("ic2.macerator", "ores", true, "change to '{t}=false' to disable the IC2 Macerator recipes for Ore Dusts");
         loadRecipeProperty("ic2.macerator", "bones", true, "change to '{t}=false' to disable the IC2 Macerator recipe for Bonemeal");
         loadRecipeProperty("ic2.macerator", "blaze", true, "change to '{t}=false' to disable the IC2 Macerator recipe for Blaze Powder");
-        loadRecipeProperty("ic2.macerator", "cobble", true, "change to '{t}=false' to disable the IC2 Macerator recipes for Cobblestone");
+        loadRecipeProperty("ic2.macerator", "cobble", true, "change to '{t}=false' to disable the IC2 Macerator recipes involving Cobblestone");
         loadRecipeProperty("ic2.macerator", "dirt", true, "change to '{t}=false' to disable the IC2 Macerator recipe for Dirt");
         loadRecipeProperty("ic2.macerator", "slag", true, "change to '{t}=false' to disable the IC2 Macerator recipe for Slag Dust");
         loadRecipeProperty("ic2.macerator", "ender", true, "change to '{t}=false' to disable the IC2 Macerator recipe for Ender Powder");

--- a/src/main/java/mods/railcraft/common/core/RailcraftConfig.java
+++ b/src/main/java/mods/railcraft/common/core/RailcraftConfig.java
@@ -369,8 +369,8 @@ public class RailcraftConfig {
         loadRecipeProperty("railcraft.cart", "bronze", true, "change to '{t}=false' to disable the bronze recipe for minecarts");
         loadRecipeProperty("railcraft.cart", "steel", true, "change to '{t}=false' to disable the steel recipe for minecarts");
         loadRecipeProperty("railcraft.cart", "vanilla.furnace", true, "change to '{t}=false' to disable the Furnace Minecart recipe");
-        loadRecipeProperty("ic2.macerator", "crushed.obsidian", true, "change to '{t}=false' to remove the IC2 Macerator recipes from Obsidian to Crushed Obsidian");
-        loadRecipeProperty("ic2.macerator", "obsidian", true, "change to '{t}=false' to remove the IC2 Macerator recipes with Obsidian input");
+        loadRecipeProperty("ic2.macerator", "crushed.obsidian", true, "change to '{t}=false' to disable the IC2 Macerator recipe from Obsidian to Crushed Obsidian");
+        loadRecipeProperty("ic2.macerator", "obsidian", true, "change to '{t}=false' to disable any IC2 Macerator recipe with Obsidian input");
         loadRecipeProperty("ic2.macerator", "charcoal", true, "change to '{t}=false' to disable the IC2 Macerator recipe for Charcoal Dust");
         loadRecipeProperty("ic2.macerator", "ores", true, "change to '{t}=false' to disable the IC2 Macerator recipes for Ore Dusts");
         loadRecipeProperty("ic2.macerator", "bones", true, "change to '{t}=false' to disable the IC2 Macerator recipe for Bonemeal");

--- a/src/main/java/mods/railcraft/common/modules/ModuleResources.java
+++ b/src/main/java/mods/railcraft/common/modules/ModuleResources.java
@@ -133,10 +133,7 @@ public class ModuleResources extends RailcraftModulePayload {
                     CraftingPlugin.addFurnaceRecipe(new ItemStack(Items.COAL, 1, 0), RailcraftItems.BOTTLE_CREOSOTE.getStack(2), 0.0F);
                     CraftingPlugin.addFurnaceRecipe(new ItemStack(Items.COAL, 1, 1), RailcraftItems.BOTTLE_CREOSOTE.getStack(1), 0.0F);
                 }
-            }
 
-            @Override
-            public void postInit() {
                 if (BlockGeneric.getBlock() != null && RailcraftConfig.isSubBlockEnabled(EnumGeneric.CRUSHED_OBSIDIAN.getTag())) {
                     ItemStack stack = EnumGeneric.CRUSHED_OBSIDIAN.getStack();
 
@@ -144,9 +141,12 @@ public class ModuleResources extends RailcraftModulePayload {
 
                     if (Mod.anyLoaded(Mod.IC2, Mod.IC2_CLASSIC) && RailcraftItems.DUST.isEnabled()) {
                         ItemStack obsidian = new ItemStack(Blocks.OBSIDIAN);
-                        IC2Plugin.removeMaceratorRecipes(recipe -> recipe.getInput().matches(obsidian) && OreDictPlugin.hasOreType("dustObsidian", recipe.getOutput()));
-                        if (RailcraftConfig.getRecipeConfig("ic2.macerator.obsidian")) {
-                            IC2Plugin.addMaceratorRecipe(new ItemStack(Blocks.OBSIDIAN), stack);
+                        final boolean crushedObsidian = RailcraftConfig.getRecipeConfig("ic2.macerator.crushed.obsidian");
+                        if (crushedObsidian || !RailcraftConfig.getRecipeConfig("ic2.macerator.obsidian")) {
+                            IC2Plugin.removeMaceratorRecipes(recipe -> recipe.getInput().matches(obsidian) && OreDictPlugin.hasOreType("dustObsidian", recipe.getOutput()));
+                        }
+                        if (crushedObsidian) {
+                            IC2Plugin.addMaceratorRecipe(obsidian, stack);
                             IC2Plugin.addMaceratorRecipe(stack, RailcraftItems.DUST.getStack(ItemDust.EnumDust.OBSIDIAN));
                         }
                     }


### PR DESCRIPTION
**The Issue**
 - #1719 Cannot configure obsidian handling in detail
 
**The Proposal**
 - Adds "ic2.macerator.crushed.obsidian" config for better control.
  - The crushed one controls if the obs -> crushed obs -> dust recipes are added.
  - The old obsidian one now determines if the other obs recipes should be removed when the crushed one is not present.
 
**Possible Side Effects**
 - Affects old configs.
 
**Alternatives**
 - There are 3 states (no obs, ic2 default, crushed obs), so I used two booleans.