### PR TITLE
Fix loot table not customizable

### DIFF
--- a/src/main/java/mods/railcraft/common/plugins/forge/LootPlugin.java
+++ b/src/main/java/mods/railcraft/common/plugins/forge/LootPlugin.java
@@ -10,30 +10,14 @@
 
 package mods.railcraft.common.plugins.forge;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Resources;
-import com.google.gson.*;
 import mods.railcraft.api.core.RailcraftConstantsAPI;
 import mods.railcraft.common.core.RailcraftConstants;
-import mods.railcraft.common.modules.RailcraftModuleManager;
-import mods.railcraft.common.util.misc.Game;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.world.storage.loot.*;
-import net.minecraft.world.storage.loot.conditions.LootCondition;
-import net.minecraft.world.storage.loot.conditions.LootConditionManager;
-import net.minecraft.world.storage.loot.functions.LootFunction;
-import net.minecraft.world.storage.loot.functions.LootFunctionManager;
-import net.minecraftforge.common.ForgeHooks;
+import net.minecraft.world.storage.loot.LootPool;
+import net.minecraft.world.storage.loot.LootTable;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.LootTableLoadEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.common.registry.ForgeRegistries;
-import org.apache.logging.log4j.Level;
-import org.jetbrains.annotations.Nullable;
-
-import java.io.IOException;
-import java.net.URL;
-import java.util.Random;
 
 import static net.minecraft.world.storage.loot.LootTableList.register;
 
@@ -51,12 +35,6 @@ public final class LootPlugin {
      */
     public static final LootPlugin INSTANCE = new LootPlugin();
     /**
-     * Name of the item exist condition.
-     *
-     * It is supposed to be {@code railcraft:item_exist} as a plain string.
-     */
-    public static final ResourceLocation ITEM_EXIST_CONDITION_NAME = RailcraftConstantsAPI.locationOf("item_exist");
-    /**
      * The location of the railcraft workshop chest loot table.
      */
     public static final ResourceLocation CHESTS_VILLAGE_WORKSHOP = register(RailcraftConstantsAPI.locationOf( "chests/village_workshop"));
@@ -70,7 +48,6 @@ public final class LootPlugin {
      */
     public void init() {
         MinecraftForge.EVENT_BUS.register(this);
-//        LootConditionManager.registerCondition(new ItemExistConditionSerializer());
     }
 
     @SubscribeEvent
@@ -80,7 +57,7 @@ public final class LootPlugin {
         }
 
         ResourceLocation resourceLocation = RailcraftConstantsAPI.locationOf(event.getName().getPath());
-        LootTable lootTable = LootTableLoader.loadBuiltinLootTable(resourceLocation, event.getLootTableManager());
+        LootTable lootTable = event.getLootTableManager().getLootTableFromLocation(resourceLocation); // Causes recursive events, but should be fine
         if (lootTable != null) {
             for (String poolName : poolNames) {
                 LootPool pool = lootTable.getPool(RailcraftConstants.RESOURCE_DOMAIN + "_" + poolName);
@@ -88,100 +65,5 @@ public final class LootPlugin {
                     event.getTable().addPool(pool);
             }
         }
-    }
-
-    /**
-     * Broken.
-     */
-    @Deprecated
-    static final class ItemExistCondition implements LootCondition {
-        final String module;
-        final ResourceLocation name;
-
-        ItemExistCondition(String module, ResourceLocation name) {
-            this.module = module;
-            this.name = name;
-        }
-
-        @Override
-        public boolean testCondition(Random rand, LootContext context) {
-            if (!RailcraftModuleManager.isModuleEnabled(module)) {
-                Game.log().msg(Level.INFO, "disabled loot item {} for disabled module {}", name, module);
-                return false;
-            }
-            if (ForgeRegistries.ITEMS.getValue(name) == null) {
-                Game.log().msg(Level.INFO, "disabled loot item {} for missing in registry", name);
-                return false;
-            }
-            return true;
-        }
-    }
-
-    /**
-     * A serializer for item exist condition.
-     */
-    @Deprecated
-    static final class ItemExistConditionSerializer extends LootCondition.Serializer<ItemExistCondition> {
-        ItemExistConditionSerializer() {
-            super(ITEM_EXIST_CONDITION_NAME, ItemExistCondition.class);
-        }
-
-        @Override
-        public void serialize(JsonObject json, ItemExistCondition value, JsonSerializationContext context) {
-            json.addProperty("module", value.module);
-            json.addProperty("name", value.name.toString());
-        }
-
-        @Override
-        public ItemExistCondition deserialize(JsonObject json, JsonDeserializationContext context) {
-            String module = json.has("module") ? json.get("module").getAsString() : "railcraft:core";
-            String name = json.get("name").getAsString();
-            return new ItemExistCondition(module, new ResourceLocation(name));
-        }
-    }
-
-    /**
-     * Copy of {@link LootTableManager} that can load Railcraft's loot table additions.
-     * This is a workaround so we can load loot table jsons that have pools to be added to vanilla's chests.
-     * During {@link LootTableLoadEvent} the world's lootTable is not set yet.
-     *
-     * @author mezz
-     */
-    static final class LootTableLoader {
-        private static final Gson GSON_INSTANCE = new GsonBuilder()
-                .registerTypeAdapter(RandomValueRange.class, new RandomValueRange.Serializer())
-                .registerTypeAdapter(LootPool.class, new LootPool.Serializer())
-                .registerTypeAdapter(LootTable.class, new LootTable.Serializer())
-                .registerTypeHierarchyAdapter(LootEntry.class, new LootEntry.Serializer())
-                .registerTypeHierarchyAdapter(LootFunction.class, new LootFunctionManager.Serializer())
-                .registerTypeHierarchyAdapter(LootCondition.class, new LootConditionManager.Serializer())
-                .registerTypeHierarchyAdapter(LootContext.EntityTarget.class, new LootContext.EntityTarget.Serializer())
-                .create();
-
-        public static @Nullable LootTable loadBuiltinLootTable(ResourceLocation resource, LootTableManager manager) {
-            URL url = LootTableLoader.class.getResource("/assets/" + resource.getNamespace() + "/loot_tables/" + resource.getPath() + ".json");
-
-            if (url != null) {
-                String s;
-
-                try {
-                    s = Resources.toString(url, Charsets.UTF_8);
-                } catch (IOException ioexception) {
-                    Game.log().throwable("Couldn\'t load loot table {0} from {1}", ioexception, resource, url);
-                    return LootTable.EMPTY_LOOT_TABLE;
-                }
-
-                try {
-                    // custom is false so that other mods can listen to the loot load event of rc custom tables
-                    return ForgeHooks.loadLootTable(GSON_INSTANCE, resource, s, false, manager);
-                } catch (JsonParseException jsonparseexception) {
-                    Game.log().throwable("Couldn\'t load loot table {0} from {1}", jsonparseexception, resource, url);
-                    return LootTable.EMPTY_LOOT_TABLE;
-                }
-            } else {
-                return null;
-            }
-        }
-
     }
 }


### PR DESCRIPTION
**The Issue**
 - Fix loot table not customizable, close #1659
 - Describe the problem if an issue doesn't exist. Be as clear as possible.
 - Also resolves Daomephsta/LootTweaker#51
 
**The Proposal**
 - Use vanilla loot table loading so that we can take account of customized loot tables in data folder and other mods, etc.
 - Now can just disable the table in loottweaker
 
**Possible Side Effects**
 - The old condition is removed because vanilla just fail fast when encountering and item that does not exist (without checking any condition first, unlike recipes)
 
**Alternatives**
 - This is a minimal change. Adding too much config or details for loot tables is too much and might cause more unexpected issues.