### PR TITLE
Prevent adjacent tile cache from loading chunks

### DIFF
--- a/src/main/java/mods/railcraft/common/plugins/forge/WorldPlugin.java
+++ b/src/main/java/mods/railcraft/common/plugins/forge/WorldPlugin.java
@@ -17,11 +17,9 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.ChunkCache;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
-import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.world.BlockEvent;
 import org.jetbrains.annotations.Nullable;
@@ -44,13 +42,13 @@ public class WorldPlugin {
         return getBlockState(world, pos).getBlock();
     }
 
+    public static @Nullable TileEntity getBlockTileWeak(World world, BlockPos pos) {
+        return isBlockLoaded(world, pos) ? getBlockTile(world, pos) : null;
+    }
+
     public static @Nullable TileEntity getBlockTile(IBlockAccess world, BlockPos pos) {
-        // see flowerpot source code
-//        if (pos.getY() < 0) { // cubic chunks
-//            // dunno if this will be triggered by tiles at y=0
-//            Game.log().msg(Level.INFO, "Attempted to access tile entity in an invalid position");
-//        }
-        return world instanceof ChunkCache ? ((ChunkCache) world).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : world.getTileEntity(pos);
+        // see flowerpot source code about chunk cache (forge patched in 1.12)
+        return world.getTileEntity(pos);
     }
 
     public static Optional<TileEntity> getTileEntity(IBlockAccess world, BlockPos pos) {

--- a/src/main/java/mods/railcraft/common/util/misc/AdjacentTileCache.java
+++ b/src/main/java/mods/railcraft/common/util/misc/AdjacentTileCache.java
@@ -43,7 +43,7 @@ public final class AdjacentTileCache {
     }
 
     private @Nullable TileEntity searchSide(EnumFacing side) {
-        return WorldPlugin.getBlockTile(source.getWorld(), source.getPos().offset(side));
+        return WorldPlugin.getBlockTileWeak(source.getWorld(), source.getPos().offset(side));
     }
 
     public void refresh() {


### PR DESCRIPTION
**The Issue**
 - Fixes #1771
 - Sometimes adjacent tile cache can load chunks when an te is just loaded during chunk loading process.
 
**The Proposal**
 - Make adjacent tile cache no longer load chunks.
 
**Possible Side Effects**
 - Adjacent tile cache would no longer load chunks and may leave some partially loaded multiblocks as partially loaded instead of valid/invalid in the future.
 
**Alternatives**
 - Moving block changes to blocks would not have access to tile data and will forget about depth.

**Extras**
Private chat history (and my reasoning) available at https://discordapp.com/channels/225184360049934336/225186263844651009/554819262137761792

Other existing usage of worldplugin getTileEntity are for the te within a block, so I did not patch them.