### PR TITLE
Adds a proper api jar and api sources jar for mods to use

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -325,14 +325,27 @@ task signDevJar(type: JarSigner, dependsOn: 'devJar') {
     outputFile = devJar.getArchivePath()
 }
 
-task apiZip(type: Zip) {
+task apiSourceJar(type: Jar) {
     from project.apiRailcraft
+    include '**/mods/railcraft/api/**/*.java'
+    from project.apiRailcraft + "/LICENSE.md"
+    include '**/LICENSE.md'
     destinationDir = file(dirDest)
-    classifier = 'api'
-    extension = 'zip'
+    classifier = 'api-sources'
+    extension = 'jar'
 }
 
-build.dependsOn signMainJar, signDevJar, apiZip
+task apiJar(type: Jar) {
+    from sourceSets.api.output
+    include '**/mods/railcraft/api/**'
+    from project.apiRailcraft + "/LICENSE.md"
+    include '**/LICENSE.md'
+    destinationDir = file(dirDest)
+    classifier = 'api'
+    extension = 'jar'
+}
+
+build.dependsOn signMainJar, signDevJar, apiSourceJar, apiJar
 uploadArchives.shouldRunAfter build
 
 if (project.hasProperty("ftpUsername"))
@@ -350,7 +363,8 @@ if (project.hasProperty("ftpUsername"))
     }
 
 artifacts {
-    archives apiZip
+    archives apiSourceJar
+    archives apiJar
     archives devJar
     archives jar
 }

--- a/src/main/java/mods/railcraft/common/advancements/criterion/MultiBlockFormedTrigger.java
+++ b/src/main/java/mods/railcraft/common/advancements/criterion/MultiBlockFormedTrigger.java
@@ -16,10 +16,10 @@ import com.mojang.authlib.GameProfile;
 import mods.railcraft.api.core.RailcraftConstantsAPI;
 import mods.railcraft.common.advancements.criterion.MultiBlockFormedTrigger.Instance;
 import mods.railcraft.common.blocks.TileRailcraft;
-import mods.railcraft.common.blocks.multi.IMultiBlockTile;
 import mods.railcraft.common.events.MultiBlockEvent;
 import mods.railcraft.common.util.json.JsonTools;
 import mods.railcraft.common.util.misc.Conditions;
+import mods.railcraft.common.util.misc.Game;
 import net.minecraft.advancements.ICriterionInstance;
 import net.minecraft.advancements.PlayerAdvancements;
 import net.minecraft.advancements.critereon.NBTPredicate;
@@ -30,7 +30,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.JsonUtils;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import org.jetbrains.annotations.Nullable;
 
@@ -71,9 +70,9 @@ final class MultiBlockFormedTrigger extends BaseTrigger<Instance> {
 
     @SubscribeEvent
     public void onMultiBlockForm(MultiBlockEvent.Form event) {
-        TileRailcraft tile = event.getMultiBlock();
+        TileRailcraft tile = event.getMaster();
         GameProfile owner = tile.getOwner();
-        MinecraftServer server = requireNonNull(FMLCommonHandler.instance().getMinecraftServerInstance());
+        MinecraftServer server = requireNonNull(Game.getServer());
         EntityPlayerMP player = server.getPlayerList().getPlayerByUUID(owner.getId());
         if (player == null) {
             return; // Offline
@@ -97,7 +96,6 @@ final class MultiBlockFormedTrigger extends BaseTrigger<Instance> {
             this.nbt = nbtPredicate;
         }
 
-        // FIXME: This used to use the master class, but I removed that function and probably broke it. - CovertJaguar
         boolean matches(TileRailcraft tile) {
             return Conditions.check(clazz, tile.getClass()) && nbt.test(tile.writeToNBT(new NBTTagCompound()));
         }

--- a/src/main/java/mods/railcraft/common/events/MultiBlockEvent.java
+++ b/src/main/java/mods/railcraft/common/events/MultiBlockEvent.java
@@ -11,18 +11,17 @@
 package mods.railcraft.common.events;
 
 import mods.railcraft.common.blocks.TileRailcraft;
-import mods.railcraft.common.blocks.multi.IMultiBlockTile;
 import net.minecraftforge.fml.common.eventhandler.Event;
 
 public abstract class MultiBlockEvent extends Event {
-    private final TileRailcraft multiBlock;
+    private final TileRailcraft master;
 
-    MultiBlockEvent(TileRailcraft tile) {
-        this.multiBlock = tile;
+    MultiBlockEvent(TileRailcraft master) {
+        this.master = master;
     }
 
-    public TileRailcraft getMultiBlock() {
-        return multiBlock;
+    public TileRailcraft getMaster() {
+        return master;
     }
 
     public static final class Form extends MultiBlockEvent {


### PR DESCRIPTION
**The Issue**
Cannot find a proper railcraft api jar for gradle dependency. I encountered this issue during development of steves carts 2 for railcraft compatibility.
See https://github.com/TechReborn/StevesCarts/pull/179
 
**The Proposal**
Add api jar with srg names and api source jars with mcp names under the latest stable 32 for mc 1.12.2 for mods to use as a flatdir dependency.
 
**Possible Side Effects**
Other mods can still use the code from railcraft or just use rc api from github. old zip users should be able to extract source jar as well.
 
**Alternatives**
In long term, I suggest setting up a maven or using bintray for maven repos.
