### PR TITLE
Allow minecart invulnerability and option to turn off fluid handler injection

### DIFF
--- a/src/main/java/mods/railcraft/common/core/RailcraftConfig.java
+++ b/src/main/java/mods/railcraft/common/core/RailcraftConfig.java
@@ -101,6 +101,8 @@ public class RailcraftConfig {
     private static boolean enablePolarExpress;
     private static boolean generateDefaultOreConfigs;
     private static boolean nerfWaterBottle;
+    private static boolean handleBottles;
+    private static boolean cartsInvulnerableFromMonsters;
     private static int minecartTankCapacity = 32;
     private static int minecartTankFillRate = 32;
     private static int launchRailMaxForce;
@@ -274,6 +276,7 @@ public class RailcraftConfig {
     private static void loadItemTweaks() {
 //        trackingAuraEnabled = get(CAT_AURAS + ".goggles", "trackingAura", true, "Change to '{t}=false' to disable the Tracking Aura");
         nerfWaterBottle = get(CAT_TWEAKS_ITEMS + "bottle.water", "nerfWaterBottle", false, "adjust to make the water bottles contain only 333 milli-bucket water, default=false");
+        handleBottles = get(CAT_TWEAKS_ITEMS + "bottle", "handleBottles", true, "change to '{t}=false' to prevent railcraft from attaching capabilities to bottles, default=true");
     }
 
     private static void loadTrackTweaks() {
@@ -303,6 +306,8 @@ public class RailcraftConfig {
         minecartsCollideWithItems = get(CAT_TWEAKS_CARTS + ".general", "collideWithItems", false, "change to '{t}=true' to restore minecart collisions with dropped items, ignored if 'register.collision.handler=false'");
 
         printLinkingDebug = get(CAT_TWEAKS_CARTS + ".general", "printLinkingDebug", false, "change to '{t}=true' to log debug info for Cart Linking");
+
+        cartsInvulnerableFromMonsters = get(CAT_TWEAKS_CARTS + ".general", "cartsInvulnerableFromMonsters", true, "change to '{t}=false' to allow monster fired projectiles to damage carts");
 
         adjustBasicCartDrag = get(CAT_TWEAKS_CARTS + ".basic", "adjustDrag", true, "change to '{t}=false' to give basic carts the original vanilla drag values, after changing you may need to replace the carts to see any change in game");
 
@@ -846,6 +851,14 @@ public class RailcraftConfig {
 
     public static boolean nerfWaterBottle() {
         return nerfWaterBottle;
+    }
+
+    public static boolean handleBottles() {
+        return handleBottles;
+    }
+
+    public static boolean cartsInvulnerableFromMonsters() {
+        return cartsInvulnerableFromMonsters;
     }
 
     public static float getMaxHighSpeed() {


### PR DESCRIPTION
**The Issue**
Allow minecarts be invulnerable from monster projectiles, close #1769
Also allow users to turn off railcraft glass bottle capability in case of capability conflict. (e.g. with better with mods, charset, cuisine, gregtech community edition)
 
**The Proposal**
Prevent monster projectile damages to carts. Shulker bullets are specially handled as they don't expose their owner. Cannot check damage source because there is no forge event available.
Allow turning off railcraft fluid capability injection for compatibility concerns.
 
**Possible Side Effects**
The monster projectiles should handle most mob-caused projectile damages; mobs do not usually have an ai to attack minecart straight.
After the capability is turned off, creosote bottles still can have creosote placed in world or extracted, but they can no longer become creosote bottles after being empty bottles.
 
**Alternatives**
@Archengius suggested delegating fluid handlers, but it turns out to be impossible because we do not know which fluid handler will be registered after ours has been.
