### PR TITLE
Allow to remove hopper transfer cooldown via config

### DIFF
--- a/src/main/java/mods/railcraft/client/core/ClientProxy.java
+++ b/src/main/java/mods/railcraft/client/core/ClientProxy.java
@@ -30,7 +30,6 @@ import mods.railcraft.common.blocks.multi.TileSteamTurbine;
 import mods.railcraft.common.blocks.multi.TileTankBase;
 import mods.railcraft.common.carts.EntityTunnelBore;
 import mods.railcraft.common.core.CommonProxy;
-import mods.railcraft.common.core.RailcraftConfig;
 import mods.railcraft.common.core.RailcraftObjects;
 import mods.railcraft.common.items.IRailcraftItemSimple;
 import mods.railcraft.common.items.RailcraftItems;
@@ -237,11 +236,6 @@ public class ClientProxy extends CommonProxy implements ISelectiveResourceReload
 //        stack = EnumCart.CARGO.getCartItem();
 //        if (stack != null)
 //            registerItemRenderer(stack.getItem(), new RenderCartItemFiltered(RenderCartItemFiltered.RendererType.Cargo));
-
-        if (RailcraftConfig.isWorldGenEnabled("workshop")) {
-            int id = RailcraftConfig.villagerID();
-//            VillagerRegistry.instance().registerVillagerSkin(id, ModuleWorld.VILLAGER_TEXTURE);
-        }
 
         Game.log().msg(Level.TRACE, "Init Complete: Renderer");
     }

--- a/src/main/java/mods/railcraft/common/carts/EntityCartHopper.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityCartHopper.java
@@ -10,6 +10,7 @@
 
 package mods.railcraft.common.carts;
 
+import mods.railcraft.common.core.RailcraftConfig;
 import mods.railcraft.common.gui.EnumGui;
 import mods.railcraft.common.util.entity.EntitySearcher;
 import mods.railcraft.common.util.inventory.IExtInvSlot;
@@ -140,7 +141,7 @@ public class EntityCartHopper extends CartBaseContainer implements IHopper {
                     transferCooldown = 0;
                 }
 
-                if (transferCooldown <= 0) {
+                if (!RailcraftConfig.hopperCartTransferCooldown() || transferCooldown <= 0) {
                     if (transferAndNeedsCooldown()) {
                         transferCooldown = 4;
                     }

--- a/src/main/java/mods/railcraft/common/core/RailcraftConfig.java
+++ b/src/main/java/mods/railcraft/common/core/RailcraftConfig.java
@@ -45,7 +45,6 @@ public class RailcraftConfig {
     private static final String COMMENT_PREFIX = "\n";
     private static final String COMMENT_SUFFIX = "\n";
     //    private static final String COMMENT_PREFIX = "\n\n   # ";
-    private static final String CAT_AURAS = "auras";
     private static final String CAT_CHARGE = "charge";
     private static final String CAT_ENCHANTMENTS = "enchantments";
     private static final String CAT_LOOT = "loot";
@@ -96,7 +95,6 @@ public class RailcraftConfig {
     private static boolean cartsAreSolid;
     private static boolean playSounds;
     private static boolean routingOpsOnly;
-    private static boolean trackingAuraEnabled;
     private static boolean enableGhostTrain;
     private static boolean enablePolarExpress;
     private static boolean generateDefaultOreConfigs;
@@ -110,7 +108,6 @@ public class RailcraftConfig {
     private static int locomotiveHorsepower;
     private static int creosoteTorchOutput;
     private static int coalCokeTorchOutput;
-    private static int villagerID;
     private static String[] enchantments;
     private static int vanillaOreGenChance = 100;
     private static int locomotiveLightLevel;
@@ -123,6 +120,7 @@ public class RailcraftConfig {
     private static float fuelPerSteamMultiplier = SteamConstants.FUEL_PER_BOILER_CYCLE;
     private static float steamLocomotiveEfficiencyMultiplier = 3F;
     private static boolean allowTankStacking;
+    private static boolean hopperCartTransferCooldown;
     public static Configuration configMain;
     public static Configuration configBlocks;
     public static Configuration configItems;
@@ -349,6 +347,8 @@ public class RailcraftConfig {
                         + "there are 1000 milli-buckets in a bucket, ignored if 'tweaks.minecarts.tank.useCustomValues=false'");
         if (minecartTankCustomize)
             minecartTankFillRate = fillRate;
+
+        hopperCartTransferCooldown = get(CAT_TWEAKS_CARTS + ".hopper", "transferCooldown", true, "change to '{t}=false' to revert fix for MC-65029 and restore the incorrect vanilla behavior, i.e. no transfer cooldown");
     }
 
     private static void loadRecipeOption() {
@@ -423,8 +423,6 @@ public class RailcraftConfig {
 
 //        mineStandardOreGenChance = get(configMain, CAT_WORLD_GEN + ".tweak", "mineStandardOreChance", 0, 20, 100, "chance that standard Ore will spawn in the core of Railcraft Ore Mines, min=0, default=20, max=100");
         vanillaOreGenChance = get(configMain, CAT_WORLD_GEN + ".tweak", "vanillaOreGenChance", 0, 100, 100, "chance that vanilla ore gen (Iron, Gold) will spawn ore uniformly throughout the world, set to zero to disable, min=0, default=100, max=100");
-
-        villagerID = configMain.get(CAT_WORLD_GEN + ".id", "workshop", 456).getInt(456);
     }
 
     private static void loadFluids() {
@@ -880,10 +878,6 @@ public class RailcraftConfig {
         return allowTankStacking;
     }
 
-    public static boolean isTrackingAuraEnabled() {
-        return trackingAuraEnabled;
-    }
-
     public static float chargeLossMultiplier() {
         return chargeLossMultiplier;
     }
@@ -908,8 +902,8 @@ public class RailcraftConfig {
         return vanillaOreGenChance;
     }
 
-    public static int villagerID() {
-        return villagerID;
+    public static boolean hopperCartTransferCooldown() {
+        return hopperCartTransferCooldown;
     }
 
     public static boolean isEnchantmentEnabled(String enchantment) {

--- a/src/main/java/mods/railcraft/common/items/ItemGoggles.java
+++ b/src/main/java/mods/railcraft/common/items/ItemGoggles.java
@@ -65,7 +65,7 @@ public class ItemGoggles extends ItemRailcraftArmor {
                 aura = 0;
             data.setByte("aura", aura);
 
-            if (getCurrentAura(goggles) == GoggleAura.TRACKING && !RailcraftConfig.isTrackingAuraEnabled())
+            if (getCurrentAura(goggles) == GoggleAura.TRACKING)
                 incrementAura(goggles);
         }
     }


### PR DESCRIPTION
**The Issue**
Fixes #1742 allow reverting our bugfix for vanilla lack of transfer cooldown.

**The Proposal**
Add a config field and check the field when applying the cooldown.
 
**Possible Side Effects**
Removed a few obsolete config entries as well.
 
**Alternatives**
