### PR TITLE
Fixes abandoned track particles

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/tracks/flex/BlockTrackFlexAbandoned.java
+++ b/src/main/java/mods/railcraft/common/blocks/tracks/flex/BlockTrackFlexAbandoned.java
@@ -55,6 +55,6 @@ public class BlockTrackFlexAbandoned extends BlockTrackFlex implements ColorPlug
 
     @Override
     public ColorPlugin.IColorFunctionBlock colorHandler() {
-        return (state, worldIn, pos, tintIndex) -> worldIn != null && pos != null ? BiomeColorHelper.getGrassColorAtPos(worldIn, pos) : ColorizerGrass.getGrassColor(0.5D, 1.0D);
+        return (state, worldIn, pos, tintIndex) -> tintIndex == 1 ? worldIn != null && pos != null ? BiomeColorHelper.getGrassColorAtPos(worldIn, pos) : ColorizerGrass.getGrassColor(0.5D, 1.0D) : 0xffffff;
     }
 }

--- a/src/main/resources/assets/railcraft/blockstates/track_flex_abandoned.json
+++ b/src/main/resources/assets/railcraft/blockstates/track_flex_abandoned.json
@@ -149,51 +149,56 @@
       }
     ],
     "grass": {
-      "true": {"model": "tall_grass"},
+      "true": {
+        "submodel": "railcraft:tinted_cross_1",
+        "textures": {
+          "cross": "minecraft:blocks/tallgrass"
+        }
+      },
       "false": {}
     },
     "shape": {
       "north_south": {
-        "submodel": "rail_flat"
+        "model": "rail_flat"
       },
       "east_west": {
-        "submodel": "rail_flat", "y": 90
+        "model": "rail_flat", "y": 90
       },
       "ascending_east": {
-        "submodel": "rail_raised_ne", "y": 90
+        "model": "rail_raised_ne", "y": 90
       },
       "ascending_west": {
-        "submodel": "rail_raised_sw", "y": 90
+        "model": "rail_raised_sw", "y": 90
       },
       "ascending_north": {
-        "submodel": "rail_raised_ne"
+        "model": "rail_raised_ne"
       },
       "ascending_south": {
-        "submodel": "rail_raised_sw"
+        "model": "rail_raised_sw"
       },
       "south_east": {
         "textures": {
           "rail": "railcraft:blocks/tracks/flex/abandoned_turned"
         },
-        "submodel": "rail_curved"
+        "model": "rail_curved"
       },
       "south_west": {
         "textures": {
           "rail": "railcraft:blocks/tracks/flex/abandoned_turned"
         },
-        "submodel": "rail_curved", "y": 90
+        "model": "rail_curved", "y": 90
       },
       "north_west": {
         "textures": {
           "rail": "railcraft:blocks/tracks/flex/abandoned_turned"
         },
-        "submodel": "rail_curved", "y": 180
+        "model": "rail_curved", "y": 180
       },
       "north_east": {
         "textures": {
           "rail": "railcraft:blocks/tracks/flex/abandoned_turned"
         },
-        "submodel": "rail_curved", "y": 270
+        "model": "rail_curved", "y": 270
       }
     }
   }

--- a/src/main/resources/assets/railcraft/models/block/tinted_cross_1.json
+++ b/src/main/resources/assets/railcraft/models/block/tinted_cross_1.json
@@ -1,0 +1,28 @@
+{
+  "ambientocclusion": false,
+  "textures": {
+    "particle": "#cross"
+  },
+  "elements": [
+    {
+      "from": [0.8, 0, 8],
+      "to": [15.2, 16, 8],
+      "rotation": {"origin": [8, 8, 8], "axis": "y", "angle": 45, "rescale": true},
+      "shade": false,
+      "faces": {
+        "north": {"uv": [0, 0, 16, 16], "texture": "#cross", "tintindex": 1},
+        "south": {"uv": [0, 0, 16, 16], "texture": "#cross", "tintindex": 1}
+      }
+    },
+    {
+      "from": [8, 0, 0.8],
+      "to": [8, 16, 15.2],
+      "rotation": {"origin": [8, 8, 8], "axis": "y", "angle": 45, "rescale": true},
+      "shade": false,
+      "faces": {
+        "west": {"uv": [0, 0, 16, 16], "texture": "#cross", "tintindex": 1},
+        "east": {"uv": [0, 0, 16, 16], "texture": "#cross", "tintindex": 1}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**The Issue**
Water moon reported on discord that abandoned track break particles are wrong.
 
**The Proposal**
Use track as main model for break particles.
Use new model for grass for preserving tint index for track particles.
 
**Possible Side Effects**
CJ said not to switch main and submodels, but i don't see any difference (maybe changes between 1.10 and 1.12 resolved that?)
 
**Alternatives**
This should be more simple than overriding methods to generate custom particles.