### PR TITLE
Fixed #1804 Charge networks fail to build properly

### DIFF
--- a/src/main/java/mods/railcraft/common/util/charge/ChargeNetwork.java
+++ b/src/main/java/mods/railcraft/common/util/charge/ChargeNetwork.java
@@ -134,28 +134,29 @@ public class ChargeNetwork implements Charge.INetwork {
      * Add the node to the network and clean up any node that used to exist there
      */
     private void addNodeImpl(BlockPos pos, ChargeNode node) {
-        if(needsNode(pos, node.chargeSpec)){
-            ChargeNode oldNode = nodes.put(pos.toImmutable(), node);
-    
-            // update the battery in the save data tracker
-            if (node.chargeBattery.isPresent())
-                worldData.initBattery(node.chargeBattery.get());
-            else
-                worldData.removeBattery(pos);
-    
-            // clean up any preexisting node
-            if (oldNode != null) {
-                oldNode.invalid = true;
-                if (oldNode.chargeGrid.isActive()) {
-                    node.chargeGrid = oldNode.chargeGrid;
-                    node.chargeGrid.add(node);
-                }
-                oldNode.chargeGrid = NULL_GRID;
+        if(!needsNode(pos, node.chargeSpec))
+            return;
+
+        ChargeNode oldNode = nodes.put(pos.toImmutable(), node);
+
+        // update the battery in the save data tracker
+        if (node.chargeBattery.isPresent())
+            worldData.initBattery(node.chargeBattery.get());
+        else
+            worldData.removeBattery(pos);
+
+        // clean up any preexisting node
+        if (oldNode != null) {
+            oldNode.invalid = true;
+            if (oldNode.chargeGrid.isActive()) {
+                node.chargeGrid = oldNode.chargeGrid;
+                node.chargeGrid.add(node);
             }
-    
-            if (node.isGridNull())
-                node.constructGrid();
+            oldNode.chargeGrid = NULL_GRID;
         }
+
+        if (node.isGridNull())
+            node.constructGrid();
     }
 
     private void removeNodeImpl(BlockPos pos) {


### PR DESCRIPTION
**The Issue**
<!-- Include the issue number this PR addresses [eg. #1567] -->
<!-- Describe the problem if an issue doesn't exist. Be as clear as possible. -->
 Charge networks fail to build properly. #1804 

**The Proposal**
<!-- Describe your changes and the reasoning behind them. -->
I added a check to see if a node still needed to be added in AddNodeImpl
Sometimes when a node is in queue to be added, something will try to access the node. when this happens the node is added twice (once by the access, and then again by the queue) and the new node can end up pointing at a grid it is not a part of. I believe this is caused by the node being added to the grid twice.

I also added a check to grid.add to prevent invalid nodes from being copied to a new grid.
 
**Possible Side Effects**
<!-- List and describe any possible side effects or unintended consequences of your addition. -->
<!-- Consider any additional changes that will need to be made in the future to support your changes. -->
it is possible that if a node incorrectly still existed in the location of the new node that it will not be updated, however the check I added is already used for screening in AddNode()
 
**Alternatives**
<!-- Describe any alternative solutions that you considered and why you rejected them. -->
One alternative was to have a loop checking x number of nodes per tick to make sure it's pointing at the grid it's actually a part of. but this is costly in terms of time and isn't a true fix of the problem

Another alternative is to remove the node creation from ChargeNetwork.Access but I was unsure of what consequences this would cause from returning NULL_NODE for a position that will eventually have a node

one last alternative would be to remove the node from the queue when it is added in AddNodeImpl. but this once again, sounds costly for something that isn't going to happen that often.
