### PR TITLE
Fix crash with Futurepack thrusters in a player's inventory

### DIFF
--- a/src/main/java/mods/railcraft/common/util/inventory/InvTools.java
+++ b/src/main/java/mods/railcraft/common/util/inventory/InvTools.java
@@ -485,7 +485,11 @@ public abstract class InvTools {
         Item item = stack.getItem();
         Block block = GameData.getBlockItemMap().inverse().get(item);
         //noinspection deprecation
-        return block == null ? Blocks.AIR.getDefaultState() : block.getStateFromMeta(stack.getItemDamage());
+        try {
+            return block == null ? Blocks.AIR.getDefaultState() : block.getStateFromMeta(stack.getItemDamage());
+        } catch (IllegalArgumentException e) {
+            return Blocks.AIR.getDefaultState();
+        }
     }
 
     public static @Nullable IBlockState getBlockStateFromStack(ItemStack stack, World world, BlockPos pos) {

--- a/src/main/java/mods/railcraft/common/util/inventory/InvTools.java
+++ b/src/main/java/mods/railcraft/common/util/inventory/InvTools.java
@@ -484,8 +484,8 @@ public abstract class InvTools {
             return Blocks.AIR.getDefaultState();
         Item item = stack.getItem();
         Block block = GameData.getBlockItemMap().inverse().get(item);
-        //noinspection deprecation
         try {
+            //noinspection deprecation
             return block == null ? Blocks.AIR.getDefaultState() : block.getStateFromMeta(stack.getItemDamage());
         } catch (IllegalArgumentException e) {
             return Blocks.AIR.getDefaultState();


### PR DESCRIPTION
Futurepack thrusters render facing up in the inventory, but cannot be placed as a block in that orientation.
This patch catches the rare case that a call to `block.getStateFromMeta(stack.getItemDamage())` throws an exception.
Without this patch, a player with a thruster in their inventory will cause a server crash.

**The Issue**
This PR fixes issue #1954 
 
**The Proposal**
In the rare case that calling getStateFromMeta on an itemstack throws an exception, this will return the default value of Blocks.AIR.getDefaultState().
 
**Possible Side Effects**
This change has the effect of treating blocks that would otherwise crash the game as air blocks, which may cause undesired behavior if the Thrusters are used in Railcraft machines. However, the alternative is crashing the server.
 
**Alternatives**
This issue may be fixable from the side of Futurepack, but a similar issue raised against that project was rejected as the other mod's fault. Patching this crash on Railcraft's side was also a matter of a few lines, making this the faster route to a fix.
