### PR TITLE
Rock crusher fix and some block interaction events.

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/logic/TradeStationLogic.java
+++ b/src/main/java/mods/railcraft/common/blocks/logic/TradeStationLogic.java
@@ -10,6 +10,7 @@
 
 package mods.railcraft.common.blocks.logic;
 
+import com.mojang.authlib.GameProfile;
 import mods.railcraft.api.core.RailcraftFakePlayer;
 import mods.railcraft.common.gui.EnumGui;
 import mods.railcraft.common.plugins.forge.VillagerPlugin;
@@ -153,7 +154,7 @@ public abstract class TradeStationLogic extends InventoryLogic {
         ItemStack buy2 = recipeSlots.getStackInSlot(tradeSet * 3 + 1);
         ItemStack sell = recipeSlots.getStackInSlot(tradeSet * 3 + 2);
         for (EntityVillager villager : villagers) {
-            MerchantRecipeList recipes = villager.getRecipes(RailcraftFakePlayer.get((WorldServer) theWorldAsserted(), getX(), getY(), getZ()));
+            MerchantRecipeList recipes = villager.getRecipes(RailcraftFakePlayer.get((WorldServer) theWorldAsserted(), getX(), getY(), getZ(), getOwner()));
             if (recipes != null) {
                 for (MerchantRecipe recipe : recipes) {
                     if (recipe.isRecipeDisabled())
@@ -209,6 +210,8 @@ public abstract class TradeStationLogic extends InventoryLogic {
                 Game.log().msg(Level.WARN, "Cannot remove second input item!");
         invOutput.addStack(InvTools.copy(recipe.getItemToSell()));
     }
+
+    protected abstract GameProfile getOwner();
 
     protected abstract EntityPlayer getOwnerEntityOrFake();
 
@@ -284,7 +287,7 @@ public abstract class TradeStationLogic extends InventoryLogic {
         } else {
             villager = villagers.iterator().next();
         }
-        MerchantRecipeList recipes = villager.getRecipes(RailcraftFakePlayer.get((WorldServer) theWorldAsserted(), getX(), getY(), getZ()));
+        MerchantRecipeList recipes = villager.getRecipes(RailcraftFakePlayer.get((WorldServer) theWorldAsserted(), getX(), getY(), getZ(), getOwner()));
         assert recipes != null;
         MerchantRecipe recipe = recipes.get(MiscTools.RANDOM.nextInt(recipes.size()));
         recipeSlots.setInventorySlotContents(tradeSet * 3, recipe.getItemToBuy());

--- a/src/main/java/mods/railcraft/common/blocks/machine/equipment/TileFeedStation.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/equipment/TileFeedStation.java
@@ -142,7 +142,7 @@ public class TileFeedStation extends TileMachineItem implements ITileExtraDataHa
                 EntityPlayer player;
                 if (Game.isHost(world)) {
                     EntityAIMateBreeding.modifyAI(animal);
-                    player = RailcraftFakePlayer.get((WorldServer) world, getPos());
+                    player = RailcraftFakePlayer.get((WorldServer) world, getPos(), getOwner());
                 } else {
                     player = null;
                 }

--- a/src/main/java/mods/railcraft/common/blocks/multi/TileRockCrusher.java
+++ b/src/main/java/mods/railcraft/common/blocks/multi/TileRockCrusher.java
@@ -178,8 +178,12 @@ public final class TileRockCrusher extends TileCrafter {
                 EntitySearcher.find(EntityItem.class).around(target).in(world).forEach(item -> {
                     if (l.useInternalCharge(SUCKING_POWER_COST)) {
                         ItemStack stack = item.getItem().copy();
-                        l.invInput.addStack(stack);
-                        item.setDead();
+                        ItemStack remainder = l.invInput.addStack(stack);
+                        if (remainder.isEmpty()) {
+                            item.setDead();
+                        } else {
+                            item.setItem(remainder);
+                        }
                     }
                 });
 

--- a/src/main/java/mods/railcraft/common/blocks/ore/ItemOreMagic.java
+++ b/src/main/java/mods/railcraft/common/blocks/ore/ItemOreMagic.java
@@ -9,10 +9,13 @@
  -----------------------------------------------------------------------------*/
 package mods.railcraft.common.blocks.ore;
 
+import com.mojang.authlib.GameProfile;
 import mods.railcraft.common.blocks.ItemBlockRailcraftSubtyped;
 import mods.railcraft.common.items.firestone.EntityItemFirestone;
+import mods.railcraft.common.plugins.forge.PlayerPlugin;
 import mods.railcraft.common.util.inventory.InvTools;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
@@ -53,7 +56,8 @@ public class ItemOreMagic extends ItemBlockRailcraftSubtyped<BlockOreMagic> {
     public @Nullable Entity createEntity(World world, Entity location, ItemStack stack) {
         if (!hasCustomEntity(stack))
             return null;
-        EntityItemFirestone entity = new EntityItemFirestone(world, location.posX, location.posY, location.posZ, stack);
+        GameProfile owner = PlayerPlugin.getItemThrowerProfile(((EntityItem) location));
+        EntityItemFirestone entity = new EntityItemFirestone(world, location.posX, location.posY, location.posZ, stack, owner);
         entity.motionX = location.motionX;
         entity.motionY = location.motionY;
         entity.motionZ = location.motionZ;

--- a/src/main/java/mods/railcraft/common/blocks/single/TileTradeStation.java
+++ b/src/main/java/mods/railcraft/common/blocks/single/TileTradeStation.java
@@ -9,6 +9,7 @@
  -----------------------------------------------------------------------------*/
 package mods.railcraft.common.blocks.single;
 
+import com.mojang.authlib.GameProfile;
 import mods.railcraft.common.blocks.RailcraftBlocks;
 import mods.railcraft.common.blocks.TileLogic;
 import mods.railcraft.common.blocks.logic.Logic;
@@ -35,6 +36,11 @@ public class TileTradeStation extends TileLogic {
                     AIPlugin.addAITask(villager, 9, new EntityAIWatchBlock(villager, RailcraftBlocks.TRADE_STATION.getDefaultState(), 4, 0.08F));
                     AIPlugin.addAITask(villager, 9, new EntityAISearchForBlock(villager, RailcraftBlocks.TRADE_STATION.getDefaultState(), 16, 0.002F));
                 }
+            }
+
+            @Override
+            protected GameProfile getOwner() {
+                return TileTradeStation.this.getOwner();
             }
 
             @Override

--- a/src/main/java/mods/railcraft/common/blocks/tracks/BlockTrackTile.java
+++ b/src/main/java/mods/railcraft/common/blocks/tracks/BlockTrackTile.java
@@ -43,7 +43,9 @@ public abstract class BlockTrackTile<T extends TileRailcraft> extends BlockTrack
     @Override
     public void dropBlockAsItemWithChance(World worldIn, BlockPos pos, IBlockState state, float chance, int fortune) {
         super.dropBlockAsItemWithChance(worldIn, pos, state, chance, fortune);
-        lastClearResult.set(clearBlock(state, worldIn, pos, harvesters.get()));
+        if (!worldIn.isRemote) {
+            lastClearResult.set(clearBlock(state, worldIn, pos, harvesters.get()));
+        }
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/carts/CartBaseMaintenance.java
+++ b/src/main/java/mods/railcraft/common/carts/CartBaseMaintenance.java
@@ -9,6 +9,7 @@
  -----------------------------------------------------------------------------*/
 package mods.railcraft.common.carts;
 
+import com.mojang.authlib.GameProfile;
 import mods.railcraft.api.carts.CartToolsAPI;
 import mods.railcraft.api.tracks.TrackToolsAPI;
 import mods.railcraft.common.blocks.tracks.TrackTools;
@@ -101,10 +102,10 @@ public abstract class CartBaseMaintenance extends CartBaseContainer {
         return dataManager.get(BLINK) > 0;
     }
 
-    protected boolean placeNewTrack(BlockPos pos, int slotStock, BlockRailBase.EnumRailDirection trackShape) {
+    protected boolean placeNewTrack(BlockPos pos, int slotStock, BlockRailBase.EnumRailDirection trackShape, GameProfile owner) {
         ItemStack trackStock = getStackInSlot(slotStock);
         if (!InvTools.isEmpty(trackStock))
-            if (TrackToolsAPI.placeRailAt(trackStock, (WorldServer) getEntityWorld(), pos)) {
+            if (TrackToolsAPI.placeRailAt(trackStock, (WorldServer) getEntityWorld(), pos, owner)) {
                 decrStackSize(slotStock, 1);
                 blink();
                 return true;

--- a/src/main/java/mods/railcraft/common/carts/CartTools.java
+++ b/src/main/java/mods/railcraft/common/carts/CartTools.java
@@ -162,7 +162,8 @@ public final class CartTools {
     }
 
     public static EntityPlayerMP getFakePlayer(EntityMinecart cart) {
-        return RailcraftFakePlayer.get((WorldServer) cart.world, cart.posX, cart.posY, cart.posZ);
+        GameProfile owner = CartToolsAPI.getCartOwner(cart);
+        return RailcraftFakePlayer.get((WorldServer) cart.world, cart.posX, cart.posY, cart.posZ, owner);
     }
 
     public static EntityPlayerMP getFakePlayerWith(EntityMinecart cart, ItemStack stack) {

--- a/src/main/java/mods/railcraft/common/carts/EntityCartTrackLayer.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityCartTrackLayer.java
@@ -10,6 +10,8 @@
 
 package mods.railcraft.common.carts;
 
+import com.mojang.authlib.GameProfile;
+import mods.railcraft.api.carts.CartToolsAPI;
 import mods.railcraft.common.blocks.tracks.TrackShapeHelper;
 import mods.railcraft.common.gui.EnumGui;
 import mods.railcraft.common.plugins.forge.WorldPlugin;
@@ -80,7 +82,8 @@ public class EntityCartTrackLayer extends CartBaseMaintenancePattern {
 
         if (isValidNewTrackPosition(pos)) {
             IBlockState targetState = WorldPlugin.getBlockState(world, pos);
-            if (placeNewTrack(pos, SLOT_STOCK, trackShape)) {
+            GameProfile owner = CartToolsAPI.getCartOwner(this);
+            if (placeNewTrack(pos, SLOT_STOCK, trackShape, owner)) {
                 targetState.getBlock().dropBlockAsItem(world, pos, targetState, 0);
             }
         }

--- a/src/main/java/mods/railcraft/common/carts/EntityCartTrackRelayer.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityCartTrackRelayer.java
@@ -9,6 +9,8 @@
  -----------------------------------------------------------------------------*/
 package mods.railcraft.common.carts;
 
+import com.mojang.authlib.GameProfile;
+import mods.railcraft.api.carts.CartToolsAPI;
 import mods.railcraft.api.items.ITrackItem;
 import mods.railcraft.api.tracks.IOutfittedTrackTile;
 import mods.railcraft.common.blocks.tracks.TrackTools;
@@ -84,20 +86,22 @@ public class EntityCartTrackRelayer extends CartBaseMaintenancePattern {
             if (nextToSuspended)
                 return;
 
-            if (InvTools.nonEmpty(trackExist) && InvTools.nonEmpty(trackStock))
+            if (InvTools.nonEmpty(trackExist) && InvTools.nonEmpty(trackStock)) {
+                GameProfile owner = CartToolsAPI.getCartOwner(this);
                 if (trackExist.getItem() instanceof ITrackItem) {
                     ITrackItem trackItem = (ITrackItem) trackExist.getItem();
                     if (trackItem.getPlacedBlock() == block) {
                         TileEntity tile = world.getTileEntity(pos);
                         if (trackItem.isPlacedTileEntity(trackExist, tile)) {
                             BlockRailBase.EnumRailDirection trackShape = removeOldTrack(pos, block);
-                            placeNewTrack(pos, SLOT_STOCK, trackShape);
+                            placeNewTrack(pos, SLOT_STOCK, trackShape, owner);
                         }
                     }
                 } else if (InvTools.isStackEqualToBlock(trackExist, block)) {
                     BlockRailBase.EnumRailDirection trackShape = removeOldTrack(pos, block);
-                    placeNewTrack(pos, SLOT_STOCK, trackShape);
+                    placeNewTrack(pos, SLOT_STOCK, trackShape, owner);
                 }
+            }
         }
     }
 

--- a/src/main/java/mods/railcraft/common/carts/EntityCartTradeStation.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityCartTradeStation.java
@@ -10,6 +10,8 @@
 
 package mods.railcraft.common.carts;
 
+import com.mojang.authlib.GameProfile;
+import mods.railcraft.api.carts.CartToolsAPI;
 import mods.railcraft.common.blocks.RailcraftBlocks;
 import mods.railcraft.common.blocks.logic.Logic;
 import mods.railcraft.common.blocks.logic.TradeStationLogic;
@@ -44,6 +46,11 @@ public class EntityCartTradeStation extends CartBaseLogic {
                     AIPlugin.addAITask(villager, 9, new EntityAIWatchEntity(villager, entity -> entity instanceof EntityCartTradeStation, 4, 0.08F));
                     AIPlugin.addAITask(villager, 9, new EntityAISearchForEntity(villager, entity -> entity instanceof EntityCartTradeStation, 16, 0.002F));
                 }
+            }
+
+            @Override
+            protected GameProfile getOwner() {
+                return CartToolsAPI.getCartOwner(EntityCartTradeStation.this);
             }
 
             @Override

--- a/src/main/java/mods/railcraft/common/carts/EntityCartUndercutter.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityCartUndercutter.java
@@ -9,6 +9,7 @@
  -----------------------------------------------------------------------------*/
 package mods.railcraft.common.carts;
 
+import com.mojang.authlib.GameProfile;
 import mods.railcraft.api.carts.CartToolsAPI;
 import mods.railcraft.common.blocks.aesthetics.post.ItemPost;
 import mods.railcraft.common.blocks.tracks.TrackShapeHelper;
@@ -157,7 +158,8 @@ public class EntityCartUndercutter extends CartBaseMaintenancePattern {
             return;
 
         if (safeToReplace(pos)) {
-            IBlockState stockBlock = InvTools.getBlockStateFromStack(stock, world, pos);
+            GameProfile owner = CartToolsAPI.getCartOwner(this);
+            IBlockState stockBlock = InvTools.getBlockStateFromStack(stock, world, pos, owner);
             //noinspection deprecation
             List<ItemStack> drops = oldState.getBlock().getDrops(world, pos, oldState, 0);
             ItemBlock item = (ItemBlock) stock.getItem();

--- a/src/main/java/mods/railcraft/common/core/Railcraft.java
+++ b/src/main/java/mods/railcraft/common/core/Railcraft.java
@@ -94,14 +94,6 @@ public final class Railcraft {
     }
 
     @Mod.EventHandler
-    public void fingerprintError(FMLFingerprintViolationEvent event) {
-        if (Game.isObfuscated()) {
-            Game.log().fingerprint(MOD_ID);
-            throw new RuntimeException("Invalid Fingerprint");
-        }
-    }
-
-    @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event) {
         RailcraftModuleManager.loadModules(event.getAsmData());
 

--- a/src/main/java/mods/railcraft/common/items/ItemCrowbar.java
+++ b/src/main/java/mods/railcraft/common/items/ItemCrowbar.java
@@ -233,7 +233,7 @@ public abstract class ItemCrowbar extends ItemTool implements IToolCrowbar, IBox
 
     private void removeExtraBlocks(World world, int level, BlockPos pos, IBlockState state, EntityPlayer player) {
         if (level > 0) {
-            WorldPlugin.playerRemoveBlock(world, pos, player);
+            WorldPlugin.playerRemoveBlock(world, pos, player.getGameProfile());
             checkBlocks(world, level, pos, player);
         }
     }

--- a/src/main/java/mods/railcraft/common/items/firestone/EntityItemFirestone.java
+++ b/src/main/java/mods/railcraft/common/items/firestone/EntityItemFirestone.java
@@ -9,22 +9,33 @@
  -----------------------------------------------------------------------------*/
 package mods.railcraft.common.items.firestone;
 
+import com.mojang.authlib.GameProfile;
+import com.sun.javafx.scene.traversal.Direction;
 import mods.railcraft.api.core.RailcraftConstantsAPI;
+import mods.railcraft.api.core.RailcraftFakePlayer;
 import mods.railcraft.common.blocks.RailcraftBlocks;
 import mods.railcraft.common.core.Railcraft;
 import mods.railcraft.common.items.EntityItemFireproof;
+import mods.railcraft.common.plugins.forge.PlayerPlugin;
 import mods.railcraft.common.plugins.forge.WorldPlugin;
 import mods.railcraft.common.util.entity.EntityIDs;
 import mods.railcraft.common.util.misc.Game;
 import mods.railcraft.common.util.misc.MiscTools;
+import net.minecraft.block.BlockEventData;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
 
 /**
@@ -34,6 +45,7 @@ public class EntityItemFirestone extends EntityItemFireproof {
 
     private int clock = MiscTools.RANDOM.nextInt(100);
     private boolean refined;
+    private GameProfile owner = RailcraftFakePlayer.UNKNOWN_USER_PROFILE;
 
     public EntityItemFirestone(World world) {
         super(world);
@@ -43,8 +55,9 @@ public class EntityItemFirestone extends EntityItemFireproof {
         super(world, x, y, z);
     }
 
-    public EntityItemFirestone(World world, double x, double y, double z, ItemStack stack) {
+    public EntityItemFirestone(World world, double x, double y, double z, ItemStack stack, GameProfile owner) {
         super(world, x, y, z, stack);
+        this.owner = owner;
     }
 
     public static void register() {
@@ -59,7 +72,7 @@ public class EntityItemFirestone extends EntityItemFireproof {
             if (clock % 4 != 0)
                 return;
             ItemStack stack = getItem();
-            FirestoneTools.trySpawnFire(world, getPosition(), stack);
+            FirestoneTools.trySpawnFire(world, getPosition(), stack, owner);
         }
     }
 
@@ -76,7 +89,15 @@ public class EntityItemFirestone extends EntityItemFireproof {
                 surface = surface.up();
                 if (WorldPlugin.isBlockAir(world, surface) && WorldPlugin.getBlockMaterial(world, surface.down()) == Material.LAVA) {
                     boolean cracked = getItem().getItem() instanceof ItemFirestoneCracked;
+
+                    net.minecraftforge.common.util.BlockSnapshot blocksnapshot = net.minecraftforge.common.util.BlockSnapshot.getBlockSnapshot(world, surface);
                     WorldPlugin.setBlockState(world, surface, firestoneBlock.withProperty(BlockRitual.CRACKED, cracked));
+                    EntityPlayerMP player = RailcraftFakePlayer.get((WorldServer) world, posX, posY, posZ, getItem(), EnumHand.MAIN_HAND, owner);
+                    if (net.minecraftforge.event.ForgeEventFactory.onPlayerBlockPlace(player, blocksnapshot, EnumFacing.UP, EnumHand.MAIN_HAND).isCanceled()) {
+                        blocksnapshot.restore(true, false);
+                        return;
+                    }
+
                     TileEntity tile = WorldPlugin.getBlockTile(world, surface);
                     if (tile instanceof TileRitual) {
                         TileRitual fireTile = (TileRitual) tile;
@@ -102,12 +123,14 @@ public class EntityItemFirestone extends EntityItemFireproof {
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound compound) {
         compound.setBoolean("refined", refined);
+        PlayerPlugin.writeOwnerToNBT(compound, owner);
         return super.writeToNBT(compound);
     }
 
     @Override
     public void readFromNBT(NBTTagCompound compound) {
         refined = compound.getBoolean("refined");
+        owner = PlayerPlugin.readOwnerFromNBT(compound);
         super.readFromNBT(compound);
     }
 }

--- a/src/main/java/mods/railcraft/common/items/firestone/FirestoneTickHandler.java
+++ b/src/main/java/mods/railcraft/common/items/firestone/FirestoneTickHandler.java
@@ -30,7 +30,10 @@ public class FirestoneTickHandler {
             return;
         if (entity instanceof EntityPlayer && ((EntityPlayer) entity).openContainer != ((EntityPlayer) entity).inventoryContainer)
             return;
-        InventoryComposite.of(entity).streamStacks().forEach(stack -> FirestoneTools.trySpawnFire(entity.world, entity.getPosition(), stack));
+        if (entity instanceof EntityPlayer) {
+            EntityPlayer player = ((EntityPlayer) entity);
+            InventoryComposite.of(entity).streamStacks().forEach(stack -> FirestoneTools.trySpawnFire(entity.world, entity.getPosition(), stack, player.getGameProfile()));
+        }
     }
 
 }

--- a/src/main/java/mods/railcraft/common/items/firestone/ItemFirestone.java
+++ b/src/main/java/mods/railcraft/common/items/firestone/ItemFirestone.java
@@ -9,8 +9,13 @@
  -----------------------------------------------------------------------------*/
 package mods.railcraft.common.items.firestone;
 
+import com.mojang.authlib.GameProfile;
+import mods.railcraft.api.core.RailcraftFakePlayer;
 import mods.railcraft.common.items.ItemRailcraft;
+import mods.railcraft.common.plugins.forge.PlayerPlugin;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
@@ -46,9 +51,9 @@ public class ItemFirestone extends ItemRailcraft {
      * @return A new Entity object to spawn or null
      */
     @Override
-
     public EntityItemFirestone createEntity(World world, Entity location, ItemStack stack) {
-        EntityItemFirestone entity = new EntityItemFirestone(world, location.posX, location.posY, location.posZ, stack);
+        GameProfile owner = PlayerPlugin.getItemThrowerProfile(((EntityItem) location));
+        EntityItemFirestone entity = new EntityItemFirestone(world, location.posX, location.posY, location.posZ, stack, owner);
         entity.motionX = location.motionX;
         entity.motionY = location.motionY;
         entity.motionZ = location.motionZ;

--- a/src/main/java/mods/railcraft/common/items/firestone/ItemFirestoneRefined.java
+++ b/src/main/java/mods/railcraft/common/items/firestone/ItemFirestoneRefined.java
@@ -9,6 +9,7 @@
  -----------------------------------------------------------------------------*/
 package mods.railcraft.common.items.firestone;
 
+import mods.railcraft.api.carts.CartToolsAPI;
 import mods.railcraft.api.crafting.Crafters;
 import mods.railcraft.common.blocks.ore.EnumOreMagic;
 import mods.railcraft.common.fluids.FluidTools;
@@ -164,7 +165,7 @@ public class ItemFirestoneRefined extends ItemFirestone {
                 if (drops.size() == 1 && !InvTools.isEmpty(drops.get(0)) && drops.get(0).getItem() instanceof ItemBlock) {
                     ItemStack cooked = FurnaceRecipes.instance().getSmeltingResult(drops.get(0));
                     if (cooked.getItem() instanceof ItemBlock) {
-                        IBlockState newState = InvTools.getBlockStateFromStack(cooked, world, pos);
+                        IBlockState newState = InvTools.getBlockStateFromStack(cooked, world, pos, player.getGameProfile());
                         if (newState != null) {
                             WorldPlugin.setBlockState(world, pos, newState);
                             SoundHelper.playSound(world, null, pos, SoundEvents.ITEM_FIRECHARGE_USE, SoundCategory.BLOCKS, 1.0F, itemRand.nextFloat() * 0.4F + 0.8F);

--- a/src/main/java/mods/railcraft/common/plugins/forge/PlayerPlugin.java
+++ b/src/main/java/mods/railcraft/common/plugins/forge/PlayerPlugin.java
@@ -16,6 +16,7 @@ import mods.railcraft.api.items.ActivationBlockingItem;
 import mods.railcraft.common.blocks.tracks.TrackTools;
 import mods.railcraft.common.util.inventory.InvTools;
 import mods.railcraft.common.util.misc.Annotations;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -56,6 +57,17 @@ public final class PlayerPlugin {
         return new GameProfile(ownerUUID, ownerName);
     }
 
+    public static GameProfile getItemThrowerProfile(EntityItem item) {
+        String thrower = item.getThrower();
+        for (EntityPlayer player : item.world.playerEntities) {
+            GameProfile profile = player.getGameProfile();
+            if (profile.getName().equalsIgnoreCase(thrower)) {
+                return profile;
+            }
+        }
+        return RailcraftFakePlayer.UNKNOWN_USER_PROFILE;
+    }
+
     public static @Nullable EntityPlayer getPlayer(World world, GameProfile gameProfile) {
         UUID playerId = gameProfile.getId();
         if (playerId != null) {
@@ -71,7 +83,7 @@ public final class PlayerPlugin {
         if (!RailcraftConstantsAPI.UNKNOWN_PLAYER.equals(owner.getName()))
             player = PlayerPlugin.getPlayer(world, owner);
         if (player == null)
-            player = RailcraftFakePlayer.get(world, pos);
+            player = RailcraftFakePlayer.get(world, pos, owner);
         return player;
     }
 

--- a/src/main/java/mods/railcraft/common/plugins/forge/WorldPlugin.java
+++ b/src/main/java/mods/railcraft/common/plugins/forge/WorldPlugin.java
@@ -9,6 +9,7 @@
  -----------------------------------------------------------------------------*/
 package mods.railcraft.common.plugins.forge;
 
+import com.mojang.authlib.GameProfile;
 import mods.railcraft.api.core.RailcraftFakePlayer;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
@@ -139,29 +140,27 @@ public class WorldPlugin {
         return world.destroyBlock(pos, world.getGameRules().getBoolean("doTileDrops"));
     }
 
-    public static boolean destroyBlockSafe(World world, BlockPos pos, @Nullable EntityPlayer actor) {
+    public static boolean destroyBlockSafe(World world, BlockPos pos, GameProfile actor) {
         return destroyBlockSafe(world, pos, actor, world.getGameRules().getBoolean("doTileDrops"));
     }
 
-    public static boolean destroyBlockSafe(World world, BlockPos pos, @Nullable EntityPlayer actor, boolean dropBlock) {
-        if (actor == null)
-            actor = RailcraftFakePlayer.get((WorldServer) world, pos);
+    public static boolean destroyBlockSafe(World world, BlockPos pos, GameProfile actor, boolean dropBlock) {
+        EntityPlayer player = RailcraftFakePlayer.get((WorldServer) world, pos, actor);
 
         // Start of Event Fire
-        if (MinecraftForge.EVENT_BUS.post(new BlockEvent.BreakEvent(world, pos, getBlockState(world, pos), actor)))
+        if (MinecraftForge.EVENT_BUS.post(new BlockEvent.BreakEvent(world, pos, getBlockState(world, pos), player)))
             return false;
         // End of Event Fire
 
         return destroyBlock(world, pos, dropBlock);
     }
 
-    public static boolean playerRemoveBlock(World world, BlockPos pos, @Nullable EntityPlayer player) {
+    public static boolean playerRemoveBlock(World world, BlockPos pos, GameProfile player) {
         return playerRemoveBlock(world, pos, player, world.getGameRules().getBoolean("doTileDrops"));
     }
 
-    public static boolean playerRemoveBlock(World world, BlockPos pos, @Nullable EntityPlayer player, boolean dropBlock) {
-        if (player == null)
-            player = RailcraftFakePlayer.get((WorldServer) world, pos);
+    public static boolean playerRemoveBlock(World world, BlockPos pos, GameProfile owner, boolean dropBlock) {
+        EntityPlayer player = RailcraftFakePlayer.get((WorldServer) world, pos, owner);
         IBlockState state = getBlockState(world, pos);
         TileEntity te = getBlockTile(world, pos);
 

--- a/src/main/java/mods/railcraft/common/util/inventory/InvTools.java
+++ b/src/main/java/mods/railcraft/common/util/inventory/InvTools.java
@@ -9,6 +9,7 @@
  -----------------------------------------------------------------------------*/
 package mods.railcraft.common.util.inventory;
 
+import com.mojang.authlib.GameProfile;
 import mods.railcraft.api.core.RailcraftFakePlayer;
 import mods.railcraft.api.items.IFilterItem;
 import mods.railcraft.api.items.InvToolsAPI;
@@ -488,14 +489,14 @@ public abstract class InvTools {
         return block == null ? Blocks.AIR.getDefaultState() : block.getStateFromMeta(stack.getItemDamage());
     }
 
-    public static @Nullable IBlockState getBlockStateFromStack(ItemStack stack, World world, BlockPos pos) {
+    public static @Nullable IBlockState getBlockStateFromStack(ItemStack stack, World world, BlockPos pos, GameProfile owner) {
         if (isEmpty(stack))
             return null;
         Item item = stack.getItem();
         if (item instanceof ItemBlock) {
             int meta = item.getMetadata(stack.getMetadata());
             if (world instanceof WorldServer)
-                return ((ItemBlock) item).getBlock().getStateForPlacement(world, pos, EnumFacing.UP, 0.5F, 0.5F, 0.5F, meta, RailcraftFakePlayer.get((WorldServer) world, pos.up()), EnumHand.MAIN_HAND);
+                return ((ItemBlock) item).getBlock().getStateForPlacement(world, pos, EnumFacing.UP, 0.5F, 0.5F, 0.5F, meta, RailcraftFakePlayer.get((WorldServer) world, pos.up(), owner), EnumHand.MAIN_HAND);
                 //TODO fix get state for placement for that hand
             else
                 //noinspection deprecation


### PR DESCRIPTION
**The Issue**
Rock crusher destroys items dropped on top when it's inventory is full.
Block interaction FakePlayer uses name `[railcraft]` which is no longer supported by many region protection mods/plugins due to uuids.
 
**The Proposal**
Fixed rock crusher bug.
Added missing block interaction events (eg. for firestone) and made them use their owner's profile (the player that placed block/cart/etc.)
 
**Possible Side Effects**
I've accidentaly removed mod signature checking in obfuscated env during testing. Because I've already commited it, it must be rolled back manually.
