### PR TITLE
Fix bug where tunnel bore entity immediately despawns when placed

### DIFF
--- a/src/main/java/mods/railcraft/common/carts/EntityTunnelBorePart.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityTunnelBorePart.java
@@ -37,18 +37,13 @@ public class EntityTunnelBorePart extends Entity {
         this.partName = partName;
         this.forwardOffset = forwardOffset;
         this.sideOffset = sideOffset;
-        double x = parent.getOffsetX(parent.posX, forwardOffset, sideOffset);
-        double z = parent.getOffsetZ(parent.posZ, forwardOffset, sideOffset);
-        setLocationAndAngles(x, parent.posY + 0.3F, z, 0.0F, 0.0F);
+        updatePosition();
     }
 
     @Override
     public void onUpdate() {
         super.onUpdate();
-
-        double x = parent.getOffsetX(parent.posX, forwardOffset, sideOffset);
-        double z = parent.getOffsetZ(parent.posZ, forwardOffset, sideOffset);
-        setLocationAndAngles(x, parent.posY + 0.3F, z, 0.0F, 0.0F);
+        updatePosition();
     }
 
     @Override
@@ -96,5 +91,11 @@ public class EntityTunnelBorePart extends Entity {
     @Override
     public boolean isEntityEqual(Entity entity) {
         return this == entity || parent == entity;
+    }
+
+    private void updatePosition() {
+        double x = parent.getOffsetX(parent.posX, forwardOffset, sideOffset);
+        double z = parent.getOffsetZ(parent.posZ, forwardOffset, sideOffset);
+        setLocationAndAngles(x, parent.posY + 0.3F, z, 0.0F, 0.0F);
     }
 }

--- a/src/main/java/mods/railcraft/common/carts/EntityTunnelBorePart.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityTunnelBorePart.java
@@ -37,6 +37,9 @@ public class EntityTunnelBorePart extends Entity {
         this.partName = partName;
         this.forwardOffset = forwardOffset;
         this.sideOffset = sideOffset;
+        double x = parent.getOffsetX(parent.posX, forwardOffset, sideOffset);
+        double z = parent.getOffsetZ(parent.posZ, forwardOffset, sideOffset);
+        setLocationAndAngles(x, parent.posY + 0.3F, z, 0.0F, 0.0F);
     }
 
     @Override


### PR DESCRIPTION
**The Issue**
This PR addresses the issue #1123 (among many duplicates). The issue was that the tunnel bore part entities would spawn at (0,0,0), and would only have their positions updated after the first `onUpdate()` call is made to the `Entity` superclass. If (0,0,0) had lava for example, the bore would almost immediately burn and be dropped after having its position updated.
 
**The Proposal**
This PR adds a position update to the constructor of `EntityTunnelBorePart`.
 
**Possible Side Effects**
I can't see this having any real side effects.
 
**Alternatives**
This seems to be the clear solution to the issue, so I didn't think of any alternatives.
