### PR TITLE
Attempted Fix on Railcraft IC2Classic Support

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/logic/IC2EmitterLogic.java
+++ b/src/main/java/mods/railcraft/common/blocks/logic/IC2EmitterLogic.java
@@ -83,31 +83,33 @@ public class IC2EmitterLogic extends Logic implements ILocatable, IMetaDelegate,
         super.onStructureChanged(isComplete, isMaster, data);
         ifWorld(world -> {
             if (Game.isHost(world)) {
-                if (isMaster) addToNet();
-                else dropFromNet();
+                if(isMaster) {
+                   if (isComplete) addToNet();
+                   else dropFromNet();
+                }
             }
         });
     }
 
     public void addToNet() {
-        dropFromNet();
+        if(added) return;
+        added = true;
         try {
             rebuildSubTiles();
             IC2Plugin.addTileToNet(this);
         } catch (Throwable error) {
             Game.log().api("IndustrialCraft", error);
         }
-        added = true;
     }
 
     public void dropFromNet() {
-        if (added)
-            try {
-                IC2Plugin.removeTileFromNet(this);
-            } catch (Throwable error) {
-                Game.log().api("IndustrialCraft", error);
-            }
+        if (!added) return;
         added = false;
+        try {
+            IC2Plugin.removeTileFromNet(this);
+        } catch (Throwable error) {
+            Game.log().api("IndustrialCraft", error);
+        }
     }
 
     @Override


### PR DESCRIPTION
IC2Classic Compat is not working. #2040
This is most likely due to a problem in how the API is used.

List of changes:
onStructureChanged changes: IsMaster is if the master is being called, this one is either always true or always false, but has no indication if the structure is valid or not. Meaning we only care about the master if we do changes, but the "isComplete" (is formed) is the indicator if the EU Stuff should be applied or not.

changes to add/drop: Basically trust the internal state, if that one is not trustworthy then you have other problems... Also just drop duplicated calls.

If a structure can be reformed while still being valid then we have different issues again.


A few things I couldn't figure out:
The master is expected to be "index = 0" in the "getSubTiles" list. As per IC2Exp specifications.
If revalidation attempts are send through the event?

Note that this patch may or may not work, I am throwing in a blind shot.
If it works great, otherwise just close this.